### PR TITLE
🎨 Palette: Make PatientCard accessible and semantically correct

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Handling Nested Interactive Elements in Cards
+**Learning:** You cannot nest a semantic `<button>` inside a clickable card (`role="button"`) as it violates the "interactive controls must not be nested" rule.
+**Action:** When a card has a primary action that covers the whole card, convert any redundant internal buttons to visual-only elements (e.g., `div` with button styling) and hide them from screen readers (`aria-hidden="true"`), or ensure they are moved out of the interactive container.

--- a/src/modules/patients/presentation/components/PatientCard.tsx
+++ b/src/modules/patients/presentation/components/PatientCard.tsx
@@ -5,11 +5,12 @@
 
 import { Card, CardContent } from '@/shared/ui/card';
 import { Badge } from '@/shared/ui/badge';
-import { Button } from '@/shared/ui/button';
+import { buttonVariants } from '@/shared/ui/button';
 import { User, Calendar, Activity, Phone } from 'lucide-react';
 import { Patient } from '../../domain';
 import { getStatusColor, getPriorityColor, PatientValidator } from '../../domain/Patient.rules';
 import { formatDate, formatPhone } from '@/core/lib/formatters';
+import { cn } from '@/shared/utils/cn';
 
 interface PatientCardProps {
   patient: Patient;
@@ -19,8 +20,22 @@ interface PatientCardProps {
 export function PatientCard({ patient, onViewDetails }: PatientCardProps) {
   const age = PatientValidator.calculateAge(patient.birthDate);
   
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onViewDetails(patient.id);
+    }
+  };
+
   return (
-    <Card className="hover:shadow-md transition-shadow cursor-pointer" onClick={() => onViewDetails(patient.id)}>
+    <Card
+      className="hover:shadow-md transition-shadow cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+      onClick={() => onViewDetails(patient.id)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      aria-label={`Ver detalhes de ${patient.name}`}
+    >
       <CardContent className="p-4">
         <div className="flex justify-between items-start mb-3">
           <div className="flex items-start gap-3">
@@ -86,17 +101,13 @@ export function PatientCard({ patient, onViewDetails }: PatientCardProps) {
           )}
         </div>
 
-        <Button 
-          variant="ghost" 
-          size="sm" 
-          className="w-full mt-4"
-          onClick={(e) => {
-            e.stopPropagation();
-            onViewDetails(patient.id);
-          }}
+        {/* Visual-only button to avoid nested interactive controls */}
+        <div
+          className={cn(buttonVariants({ variant: "ghost", size: "sm" }), "w-full mt-4")}
+          aria-hidden="true"
         >
           Ver Detalhes
-        </Button>
+        </div>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
Improved the accessibility of `PatientCard` by making the entire card a semantic button and fixing the invalid nested interactive element issue. This ensures keyboard users can navigate and activate the card, and screen readers perceive it correctly.

---
*PR created automatically by Jules for task [7366520602711036182](https://jules.google.com/task/7366520602711036182) started by @mateuscarlos*