### PR TITLE
⚡ Bolt: Add route-based code splitting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+## 2025-02-18 - Route-based Code Splitting Pattern
+**Learning:** When implementing code splitting for routes that use named exports (barrel files), `React.lazy` requires a default export. We must bridge this by returning an object with a `default` property in the import promise: `import('...').then(m => ({ default: m.Component }))`.
+**Action:** Always check if route components are default or named exports before converting to `lazy`. Use the wrapper pattern for named exports.
+
+## 2025-02-18 - Nested Suspense for Layouts
+**Learning:** Placing a `Suspense` boundary inside the Layout component (wrapping `Outlet`) instead of just at the top level allows the sidebar/header to remain visible while the page content loads.
+**Action:** Identify Layout components and wrap their `Outlet` in `Suspense` to avoid "white screen" flashes during navigation.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from "react";
 import { Toaster } from "@/shared/ui/toaster";
 import { Toaster as Sonner } from "@/shared/ui/sonner";
 import { TooltipProvider } from "@/shared/ui/tooltip";
@@ -6,14 +7,16 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { queryClient } from "@/core/lib/query-client";
 import { validateEnv } from "@/core/config/env.config";
 import AppLayout from "./components/layout/AppLayout";
-import Dashboard from "./pages/Dashboard";
-import { PatientsPage } from "@/modules/patients/presentation/pages";
-import { InventoryPage } from "@/modules/inventory/presentation/pages";
-import { ReportsPage } from "@/modules/reports/presentation/pages";
-import { UsersPage } from "@/modules/users/presentation/pages";
-import InsurersPage from "./pages/Insurers";
-import ProvidersPage from "./pages/Providers";
-import NotFound from "./pages/NotFound";
+import { LoadingSpinner } from "@/shared/ui/loading-spinner";
+
+const Dashboard = lazy(() => import("./pages/Dashboard"));
+const PatientsPage = lazy(() => import("@/modules/patients/presentation/pages").then(module => ({ default: module.PatientsPage })));
+const InventoryPage = lazy(() => import("@/modules/inventory/presentation/pages").then(module => ({ default: module.InventoryPage })));
+const ReportsPage = lazy(() => import("@/modules/reports/presentation/pages").then(module => ({ default: module.ReportsPage })));
+const UsersPage = lazy(() => import("@/modules/users/presentation/pages").then(module => ({ default: module.UsersPage })));
+const InsurersPage = lazy(() => import("./pages/Insurers"));
+const ProvidersPage = lazy(() => import("./pages/Providers"));
+const NotFound = lazy(() => import("./pages/NotFound"));
 
 // Validar variáveis de ambiente na inicialização
 validateEnv();
@@ -24,18 +27,20 @@ const App = () => (
       <Toaster />
       <Sonner />
       <BrowserRouter>
-        <Routes>
-          <Route element={<AppLayout />}>
-            <Route path="/" element={<Dashboard />} />
-            <Route path="/patients" element={<PatientsPage />} />
-            <Route path="/inventory" element={<InventoryPage />} />
-            <Route path="/reports" element={<ReportsPage />} />
-            <Route path="/users" element={<UsersPage />} />
-            <Route path="/insurers" element={<InsurersPage />} />
-            <Route path="/providers" element={<ProvidersPage />} />
-          </Route>
-          <Route path="*" element={<NotFound />} />
-        </Routes>
+        <Suspense fallback={<div className="h-screen w-screen flex items-center justify-center"><LoadingSpinner /></div>}>
+          <Routes>
+            <Route element={<AppLayout />}>
+              <Route path="/" element={<Dashboard />} />
+              <Route path="/patients" element={<PatientsPage />} />
+              <Route path="/inventory" element={<InventoryPage />} />
+              <Route path="/reports" element={<ReportsPage />} />
+              <Route path="/users" element={<UsersPage />} />
+              <Route path="/insurers" element={<InsurersPage />} />
+              <Route path="/providers" element={<ProvidersPage />} />
+            </Route>
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </Suspense>
       </BrowserRouter>
     </TooltipProvider>
   </QueryClientProvider>

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useState, Suspense } from "react";
 import { Link, useLocation, Outlet } from "react-router-dom";
+import { LoadingSpinner } from "@/shared/ui/loading-spinner";
 import { 
   LayoutDashboard, 
   Users, 
@@ -164,7 +165,9 @@ const AppLayout = () => {
         </header>
 
         <main className="flex-1 overflow-y-auto p-4 md:p-8">
-          <Outlet />
+          <Suspense fallback={<div className="h-full w-full flex items-center justify-center"><LoadingSpinner /></div>}>
+            <Outlet />
+          </Suspense>
         </main>
       </div>
     </div>

--- a/src/shared/ui/loading-spinner.tsx
+++ b/src/shared/ui/loading-spinner.tsx
@@ -1,0 +1,15 @@
+import { Loader2 } from "lucide-react";
+import { cn } from "@/shared/utils/cn";
+
+interface LoadingSpinnerProps extends React.HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+export function LoadingSpinner({ className, size = 48, ...props }: LoadingSpinnerProps) {
+  return (
+    <div className={cn("flex flex-col items-center justify-center", className)} {...props}>
+      <Loader2 className="animate-spin text-primary" size={size} />
+      <span className="sr-only">Carregando...</span>
+    </div>
+  );
+}


### PR DESCRIPTION
💡 What: Implemented code splitting for all major route components using `React.lazy` and `Suspense`. Added a `LoadingSpinner` component and placed `Suspense` boundaries in `App.tsx` and `AppLayout.tsx`.

🎯 Why: The application was loading all page components in the main bundle, increasing the initial load time. Splitting the code ensures that users only download the code for the route they are currently visiting.

📊 Impact: Reduces the initial JavaScript bundle size significantly. Each page (Patients, Inventory, etc.) is now a separate chunk. This will improve First Contentful Paint (FCP) and Time to Interactive (TTI).

🔬 Measurement: 
1. Run `pnpm build` and observe the output chunks. You should see separate files for each page (e.g., `Insurers-[hash].js`, `Dashboard-[hash].js`).
2. Serve the production build (`pnpm preview`).
3. Open the browser's Network tab.
4. Reload the page. The initial JS transfer should be smaller.
5. Navigate to a new route (e.g., /patients). You should see a new JS request for that specific chunk.


---
*PR created automatically by Jules for task [17651933060200420027](https://jules.google.com/task/17651933060200420027) started by @mateuscarlos*