### PR TITLE
🛡️ Sentinel: Stop tracking .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-# Environment Variables (Development)
-# Backend Flask rodando no servidor Linux (192.168.10.110)
-VITE_API_BASE_URL=http://192.168.10.110:5000/api/v1
-VITE_API_TIMEOUT=10000
-VITE_ENABLE_MOCK_DATA=false

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-01 - Committed Environment Secrets
+**Vulnerability:** The `.env` file containing environment variables (potentially secrets) was tracked in the git repository.
+**Learning:** Initial project setup or template generation failed to include `.env` in `.gitignore`, leading to accidental tracking of local configuration.
+**Prevention:** Always verify `.gitignore` includes sensitive file patterns (`.env`, `*.pem`, etc.) before the first commit. Use pre-commit hooks to scan for secrets.


### PR DESCRIPTION
Security Fix:
- Removed `.env` from git tracking to prevent secrets leakage.
- Added `.env` to `.gitignore`.
- Created `.jules/sentinel.md` with security journal entry.
- Verified `.env.example` exists for configuration reference.

Impact: Prevents accidental commit of sensitive environment variables.

---
*PR created automatically by Jules for task [15447847372406423655](https://jules.google.com/task/15447847372406423655) started by @mateuscarlos*