### PR TITLE
⚡ Remove artificial delays in Patients module

### DIFF
--- a/src/modules/patients/presentation/hooks/usePatients.ts
+++ b/src/modules/patients/presentation/hooks/usePatients.ts
@@ -21,9 +21,6 @@ export function usePatients(filters: PatientFilters = {}) {
     queryFn: async () => {
       // Se mock está habilitado, retorna dados mockados
       if (ENV.ENABLE_MOCK_DATA) {
-        // Simular delay de rede
-        await new Promise(resolve => setTimeout(resolve, 500));
-        
         // Filtrar dados mockados
         let filtered = [...mockPatients];
         
@@ -64,7 +61,6 @@ export function usePatient(id: string) {
     queryKey: QUERY_KEYS.PATIENTS.detail(id),
     queryFn: async () => {
       if (ENV.ENABLE_MOCK_DATA) {
-        await new Promise(resolve => setTimeout(resolve, 300));
         const patient = mockPatients.find(p => p.id === id);
         if (!patient) throw new Error('Paciente não encontrado');
         return patient;
@@ -192,7 +188,6 @@ export function usePatientStats() {
     queryKey: ['patients', 'stats'],
     queryFn: async () => {
       if (ENV.ENABLE_MOCK_DATA) {
-        await new Promise(resolve => setTimeout(resolve, 300));
         return {
           total: mockPatients.length,
           active: mockPatients.filter(p => p.status === 'Ativo').length,


### PR DESCRIPTION
💡 **What:**
- Removed `await new Promise(resolve => setTimeout(resolve, 500))` from `usePatients` hook.
- Removed `await new Promise(resolve => setTimeout(resolve, 300))` from `usePatient` hook.
- Removed `await new Promise(resolve => setTimeout(resolve, 300))` from `usePatientStats` hook.

🎯 **Why:**
- These artificial delays were simulating network latency for mock data, but they slowed down development and testing unnecessarily. Removing them provides instant feedback when using mock data.

📊 **Measured Improvement:**
- **Baseline:** ~501ms for list query, ~301ms for stats query.
- **Optimized:** <1ms for both.
- **Improvement:** >99% reduction in latency for mock data requests.

---
*PR created automatically by Jules for task [13595138668684864842](https://jules.google.com/task/13595138668684864842) started by @mateuscarlos*