### PR TITLE
⚡ Remove artificial delay in inventory query

### DIFF
--- a/src/modules/inventory/presentation/hooks/useInventory.ts
+++ b/src/modules/inventory/presentation/hooks/useInventory.ts
@@ -16,8 +16,6 @@ export function useInventoryItems(filters: InventoryFilters = {}) {
     queryKey: QUERY_KEYS.INVENTORY.list(filters),
     queryFn: async () => {
       if (ENV.ENABLE_MOCK_DATA) {
-        await new Promise(resolve => setTimeout(resolve, 400));
-        
         let filtered = [...mockInventoryItems];
         
         if (filters.search) {


### PR DESCRIPTION
Removed an artificial 400ms delay in `useInventoryItems` hook to improve performance when using mock data.

**Benchmark Results:**
- Baseline: ~401ms
- Optimized: ~0ms
- Improvement: ~401ms (100% reduction in artificial latency)

---
*PR created automatically by Jules for task [3473270349183202800](https://jules.google.com/task/3473270349183202800) started by @mateuscarlos*