### PR TITLE
🛡️ Sentinel: Fix critical password validation bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `.env` file containing environment variables (potentially secrets) was tracked in the git repository.
 **Learning:** Initial project setup or template generation failed to include `.env` in `.gitignore`, leading to accidental tracking of local configuration.
 **Prevention:** Always verify `.gitignore` includes sensitive file patterns (`.env`, `*.pem`, etc.) before the first commit. Use pre-commit hooks to scan for secrets.
+
+## 2026-02-01 - The Truthiness Trap in Validation
+**Vulnerability:** Password validation was bypassed because the check `!isStrongPassword(password)` evaluated to `false` even for weak passwords. The `isStrongPassword` function returned a non-null object `{ isValid: boolean, ... }`, which is always truthy in JavaScript/TypeScript.
+**Learning:** Returning complex objects from validator functions without explicit boolean checks in the consumer can lead to silent security failures. The type system doesn't prevent `if (!object)` unless strict boolean checks are enforced.
+**Prevention:** Always extract the boolean property (e.g., `.isValid`) when consuming validator functions that return objects. Consider using `eslint` rules like `@typescript-eslint/strict-boolean-expressions` to catch this.

--- a/src/modules/users/domain/User.rules.ts
+++ b/src/modules/users/domain/User.rules.ts
@@ -37,7 +37,7 @@ export class UserValidator {
 
     if (!password) {
       errors.push('Senha obrigatória');
-    } else if (!isStrongPassword(password)) {
+    } else if (!isStrongPassword(password).isValid) {
       errors.push('Senha deve ter no mínimo 8 caracteres, incluindo letra maiúscula, minúscula e número');
     }
 


### PR DESCRIPTION
This PR fixes a critical security vulnerability in the password validation logic.

The `isStrongPassword` validator returns an object `{ isValid: boolean, errors: string[] }`, but the consumer in `User.rules.ts` was treating it as a boolean. In JavaScript, non-null objects are truthy, so the check `if (!isStrongPassword(password))` was always false, causing the validation to pass even for weak passwords.

I have updated the code to checks `isStrongPassword(password).isValid`.

I also added a Sentinel journal entry in `.jules/sentinel.md` to document this "Truthiness Trap" pattern for future reference.

---
*PR created automatically by Jules for task [12960152735274673488](https://jules.google.com/task/12960152735274673488) started by @mateuscarlos*