### PR TITLE
🎨 Palette: Add Skip to Content Link

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - The Invisible Power of Skip Links
+**Learning:** Skip links are often forgotten because they are invisible to mouse users, but they are critical for keyboard navigation efficiency. They allow users to bypass repetitive navigation menus and get straight to the content.
+**Action:** Always verify layouts have a bypass mechanism for repetitive navigation. Implement as `sr-only focus:not-sr-only`.

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -136,6 +136,13 @@ const AppLayout = () => {
 
   return (
     <div className="flex h-screen bg-gray-50 overflow-hidden">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-background focus:text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+      >
+        Pular para o conteúdo principal
+      </a>
+
       {/* Desktop Sidebar */}
       <aside className="hidden md:block w-64 h-full">
         <Sidebar className="h-full" />
@@ -164,7 +171,7 @@ const AppLayout = () => {
           </Sheet>
         </header>
 
-        <main className="flex-1 overflow-y-auto p-4 md:p-8">
+        <main id="main-content" className="flex-1 overflow-y-auto p-4 md:p-8">
           <Suspense fallback={<div className="h-full w-full flex items-center justify-center"><LoadingSpinner /></div>}>
             <Outlet />
           </Suspense>


### PR DESCRIPTION
Added a "Skip to content" link in AppLayout.tsx that becomes visible on focus, allowing keyboard users to bypass the sidebar navigation. Also added `id="main-content"` to the main content area to support this functionality. Documented the learning in .jules/palette.md.

---
*PR created automatically by Jules for task [9694532673348455367](https://jules.google.com/task/9694532673348455367) started by @mateuscarlos*