### PR TITLE
feat: Actionable Empty States in Patient List

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Actionable Empty States
+**Learning:** Empty states (like "No results found") are dead ends if they don't provide a way out. Users often feel stuck or think the system is broken.
+**Action:** Always provide a primary action in empty states. For search/filter results, offer a "Clear Filters" button. For empty lists, offer a "Create New" button. This turns a dead end into a helpful guide.

--- a/src/modules/patients/presentation/components/PatientFilters.tsx
+++ b/src/modules/patients/presentation/components/PatientFilters.tsx
@@ -22,26 +22,29 @@ import {
 import { PatientStatus, PatientPriority } from '../../domain';
 
 interface PatientFiltersProps {
+  searchValue?: string;
+  statusValue?: PatientStatus;
+  priorityValue?: PatientPriority;
   onSearchChange: (search: string) => void;
   onStatusChange: (status: PatientStatus | 'all') => void;
   onPriorityChange: (priority: PatientPriority | 'all') => void;
 }
 
 export function PatientFilters({
+  searchValue = '',
+  statusValue,
+  priorityValue,
   onSearchChange,
   onStatusChange,
   onPriorityChange,
 }: PatientFiltersProps) {
-  const [search, setSearch] = useState('');
   const [showFilters, setShowFilters] = useState(false);
 
   const handleSearchChange = (value: string) => {
-    setSearch(value);
     onSearchChange(value);
   };
 
   const handleClearSearch = () => {
-    setSearch('');
     onSearchChange('');
   };
 
@@ -58,10 +61,10 @@ export function PatientFilters({
             aria-label="Buscar pacientes"
             placeholder="Buscar por nome, prontuário ou CPF..."
             className="pl-9 pr-9 [&::-webkit-search-cancel-button]:hidden"
-            value={search}
+            value={searchValue}
             onChange={(e) => handleSearchChange(e.target.value)}
           />
-          {search && (
+          {searchValue && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
@@ -107,7 +110,10 @@ export function PatientFilters({
         >
           <div>
             <label className="text-sm font-medium mb-2 block">Status</label>
-            <Select onValueChange={(value) => onStatusChange(value as PatientStatus | 'all')}>
+            <Select
+              value={statusValue || 'all'}
+              onValueChange={(value) => onStatusChange(value as PatientStatus | 'all')}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Todos os status" />
               </SelectTrigger>
@@ -123,7 +129,10 @@ export function PatientFilters({
 
           <div>
             <label className="text-sm font-medium mb-2 block">Prioridade</label>
-            <Select onValueChange={(value) => onPriorityChange(value as PatientPriority | 'all')}>
+            <Select
+              value={priorityValue || 'all'}
+              onValueChange={(value) => onPriorityChange(value as PatientPriority | 'all')}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Todas as prioridades" />
               </SelectTrigger>

--- a/src/modules/patients/presentation/components/PatientList.tsx
+++ b/src/modules/patients/presentation/components/PatientList.tsx
@@ -8,6 +8,7 @@ import { Patient } from '../../domain';
 import { Skeleton } from '@/shared/ui/skeleton';
 import { AlertCircle } from 'lucide-react';
 import { Alert, AlertDescription } from '@/shared/ui/alert';
+import { Button } from '@/shared/ui/button';
 
 interface PatientListProps {
   patients: Patient[];
@@ -15,6 +16,8 @@ interface PatientListProps {
   isError: boolean;
   error?: Error | null;
   onViewDetails: (id: string) => void;
+  hasActiveFilters?: boolean;
+  onClearFilters?: () => void;
 }
 
 export function PatientList({ 
@@ -22,7 +25,9 @@ export function PatientList({
   isLoading, 
   isError, 
   error,
-  onViewDetails 
+  onViewDetails,
+  hasActiveFilters,
+  onClearFilters,
 }: PatientListProps) {
   // Loading State
   if (isLoading) {
@@ -57,9 +62,17 @@ export function PatientList({
           <AlertCircle className="w-8 h-8 text-muted-foreground" />
         </div>
         <h3 className="text-lg font-semibold mb-2">Nenhum paciente encontrado</h3>
-        <p className="text-muted-foreground">
-          Ajuste os filtros ou cadastre um novo paciente
+        <p className="text-muted-foreground mb-6">
+          {hasActiveFilters
+            ? "Não encontramos pacientes com os filtros selecionados."
+            : "Ajuste os filtros ou cadastre um novo paciente"}
         </p>
+
+        {hasActiveFilters && onClearFilters && (
+          <Button variant="outline" onClick={onClearFilters}>
+            Limpar Filtros
+          </Button>
+        )}
       </div>
     );
   }

--- a/src/modules/patients/presentation/pages/PatientsPage.tsx
+++ b/src/modules/patients/presentation/pages/PatientsPage.tsx
@@ -46,6 +46,15 @@ export function PatientsPage() {
     }));
   };
 
+  const handleClearFilters = () => {
+    setFilters({
+      page: 1,
+      pageSize: 20,
+    });
+  };
+
+  const hasActiveFilters = !!filters.search || !!filters.status || !!filters.priority;
+
   const handleViewDetails = (id: string) => {
     // TODO: Navegar para página de detalhes ou abrir modal
     console.log('Ver detalhes do paciente:', id);
@@ -95,6 +104,9 @@ export function PatientsPage() {
         </CardHeader>
         <CardContent>
           <PatientFilters
+            searchValue={filters.search}
+            statusValue={filters.status}
+            priorityValue={filters.priority}
             onSearchChange={handleSearchChange}
             onStatusChange={handleStatusChange}
             onPriorityChange={handlePriorityChange}
@@ -141,6 +153,8 @@ export function PatientsPage() {
             isError={isError}
             error={error}
             onViewDetails={handleViewDetails}
+            hasActiveFilters={hasActiveFilters}
+            onClearFilters={handleClearFilters}
           />
         </CardContent>
       </Card>


### PR DESCRIPTION
This PR implements an actionable empty state for the Patient List. Previously, when a user filtered the list and got no results, they saw a generic "No patients found" message with no direct way to reset. Now, a "Clear Filters" button appears, which resets the filters and clears the search input, improving the recovery flow. The PatientFilters component was refactored to be controlled to support this behavior.

---
*PR created automatically by Jules for task [17074269626849775190](https://jules.google.com/task/17074269626849775190) started by @mateuscarlos*