### PR TITLE
🎨 Palette: Add accessibility labels to address search button

### DIFF
--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -20,6 +20,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Textarea } from '@/shared/ui/textarea';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card';
 import { useToast } from '@/shared/hooks/use-toast';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
 
 interface PatientFormProps {
   onSubmit: (data: PatientFormData) => void;
@@ -215,19 +216,27 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                       setValue('zipCode', unmaskCEP(masked));
                     }}
                   />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    onClick={handleFetchAddress}
-                    disabled={loadingCep}
-                  >
-                    {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Search className="h-4 w-4" />
-                    )}
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={handleFetchAddress}
+                        disabled={loadingCep}
+                        aria-label="Buscar endereço pelo CEP"
+                      >
+                        {loadingCep ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Search className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Buscar endereço pelo CEP</p>
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 {errors.zipCode && (
                   <p className="text-sm text-destructive">{errors.zipCode.message}</p>


### PR DESCRIPTION
🎨 **Palette: Accessibility Improvement for Patient Form**

I've added a micro-UX enhancement to the Patient Registration form.

**💡 What:**
Added a tooltip and ARIA label to the "Search Address" (magnifying glass) button next to the CEP field.

**🎯 Why:**
- **Accessibility:** Screen readers previously announced this as "button", which was confusing. Now they read "Buscar endereço pelo CEP".
- **Usability:** Sighted users now get a helpful tooltip explaining what the button does on hover.

**📸 Verification:**
Verified using a Playwright script that confirmed the presence of the ARIA label and the visibility of the tooltip on hover.


---
*PR created automatically by Jules for task [13908309114770033337](https://jules.google.com/task/13908309114770033337) started by @mateuscarlos*