### PR TITLE
⚡ Bolt: Optimize PatientsPage re-renders

### DIFF
--- a/src/modules/patients/presentation/components/PatientCard.tsx
+++ b/src/modules/patients/presentation/components/PatientCard.tsx
@@ -10,13 +10,14 @@ import { User, Calendar, Activity, Phone } from 'lucide-react';
 import { Patient } from '../../domain';
 import { getStatusColor, getPriorityColor, PatientValidator } from '../../domain/Patient.rules';
 import { formatDate, formatPhone } from '@/core/lib/formatters';
+import { memo } from 'react';
 
 interface PatientCardProps {
   patient: Patient;
   onViewDetails: (id: string) => void;
 }
 
-export function PatientCard({ patient, onViewDetails }: PatientCardProps) {
+export const PatientCard = memo(function PatientCard({ patient, onViewDetails }: PatientCardProps) {
   const age = PatientValidator.calculateAge(patient.birthDate);
   
   return (
@@ -100,4 +101,4 @@ export function PatientCard({ patient, onViewDetails }: PatientCardProps) {
       </CardContent>
     </Card>
   );
-}
+});

--- a/src/modules/patients/presentation/components/PatientList.tsx
+++ b/src/modules/patients/presentation/components/PatientList.tsx
@@ -8,6 +8,7 @@ import { Patient } from '../../domain';
 import { Skeleton } from '@/shared/ui/skeleton';
 import { AlertCircle } from 'lucide-react';
 import { Alert, AlertDescription } from '@/shared/ui/alert';
+import { memo } from 'react';
 
 interface PatientListProps {
   patients: Patient[];
@@ -17,7 +18,7 @@ interface PatientListProps {
   onViewDetails: (id: string) => void;
 }
 
-export function PatientList({ 
+export const PatientList = memo(function PatientList({
   patients, 
   isLoading, 
   isError, 
@@ -76,4 +77,4 @@ export function PatientList({
       ))}
     </div>
   );
-}
+});

--- a/src/modules/patients/presentation/pages/PatientsPage.tsx
+++ b/src/modules/patients/presentation/pages/PatientsPage.tsx
@@ -4,7 +4,7 @@
  * Arquitetura modular: separação de domínio, dados e apresentação
  */
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
@@ -26,30 +26,31 @@ export function PatientsPage() {
 
   const { data, isLoading, isError, error } = usePatients(filters);
 
-  const handleSearchChange = (search: string) => {
+  // Memoized handlers to prevent unnecessary re-renders of child components
+  const handleSearchChange = useCallback((search: string) => {
     setFilters(prev => ({ ...prev, search: search || undefined, page: 1 }));
-  };
+  }, []);
 
-  const handleStatusChange = (status: PatientStatus | 'all') => {
+  const handleStatusChange = useCallback((status: PatientStatus | 'all') => {
     setFilters(prev => ({ 
       ...prev, 
       status: status === 'all' ? undefined : status,
       page: 1 
     }));
-  };
+  }, []);
 
-  const handlePriorityChange = (priority: PatientPriority | 'all') => {
+  const handlePriorityChange = useCallback((priority: PatientPriority | 'all') => {
     setFilters(prev => ({ 
       ...prev, 
       priority: priority === 'all' ? undefined : priority,
       page: 1 
     }));
-  };
+  }, []);
 
-  const handleViewDetails = (id: string) => {
+  const handleViewDetails = useCallback((id: string) => {
     // TODO: Navegar para página de detalhes ou abrir modal
     console.log('Ver detalhes do paciente:', id);
-  };
+  }, []);
 
   const handleCreatePatient = () => {
     setIsFormOpen(true);


### PR DESCRIPTION
*   💡 What: Wrapped `PatientCard` and `PatientList` in `React.memo` and memoized event handlers in `PatientsPage` using `useCallback`.
*   🎯 Why: Opening the "New Patient" modal was causing the entire list of patients to re-render unnecessarily, degrading performance on slower devices.
*   📊 Impact: Reduces re-renders of patient cards from N (number of cards) to 0 when interacting with page-level state (like modals).
*   🔬 Measurement: Verified using Playwright script counting console logs during modal interaction.

---
*PR created automatically by Jules for task [4638766209177953014](https://jules.google.com/task/4638766209177953014) started by @mateuscarlos*