### PR TITLE
🎨 Palette: Add actionable empty state to Patient List

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Actionable Empty States
+**Learning:** Empty states (like "No results found") are dead ends if they don't provide a way out.
+**Action:** When a list is empty due to filters, always provide a clear "Clear Filters" button directly in the empty state view. This reduces cognitive load and saves clicks.

--- a/src/modules/patients/presentation/components/PatientFilters.tsx
+++ b/src/modules/patients/presentation/components/PatientFilters.tsx
@@ -3,7 +3,7 @@
  * Barra de filtros e busca de pacientes
  */
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Input } from '@/shared/ui/input';
 import { Button } from '@/shared/ui/button';
 import { Search, Filter, X } from 'lucide-react';
@@ -22,18 +22,30 @@ import {
 import { PatientStatus, PatientPriority } from '../../domain';
 
 interface PatientFiltersProps {
+  currentSearch?: string;
+  currentStatus?: PatientStatus;
+  currentPriority?: PatientPriority;
   onSearchChange: (search: string) => void;
   onStatusChange: (status: PatientStatus | 'all') => void;
   onPriorityChange: (priority: PatientPriority | 'all') => void;
 }
 
 export function PatientFilters({
+  currentSearch = '',
+  currentStatus,
+  currentPriority,
   onSearchChange,
   onStatusChange,
   onPriorityChange,
 }: PatientFiltersProps) {
-  const [search, setSearch] = useState('');
+  // Local state for search to avoid UI lag while typing, though we sync with parent
+  const [search, setSearch] = useState(currentSearch);
   const [showFilters, setShowFilters] = useState(false);
+
+  // Update local state when prop changes (e.g. when cleared by parent)
+  useEffect(() => {
+    setSearch(currentSearch);
+  }, [currentSearch]);
 
   const handleSearchChange = (value: string) => {
     setSearch(value);
@@ -90,6 +102,7 @@ export function PatientFilters({
               aria-expanded={showFilters}
               aria-controls="advanced-filters-panel"
               aria-label="Alternar filtros avançados"
+              className={showFilters || currentStatus || currentPriority ? "bg-accent text-accent-foreground" : ""}
             >
               <Filter className="h-4 w-4" />
             </Button>
@@ -107,23 +120,30 @@ export function PatientFilters({
         >
           <div>
             <label className="text-sm font-medium mb-2 block">Status</label>
-            <Select onValueChange={(value) => onStatusChange(value as PatientStatus | 'all')}>
+            <Select
+              value={currentStatus || 'all'}
+              onValueChange={(value) => onStatusChange(value as PatientStatus | 'all')}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Todos os status" />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">Todos</SelectItem>
+                <SelectItem value={PatientStatus.EVALUATION}>Avaliação</SelectItem>
                 <SelectItem value={PatientStatus.ACTIVE}>Ativo</SelectItem>
-                <SelectItem value={PatientStatus.PENDING}>Pendente</SelectItem>
-                <SelectItem value={PatientStatus.DISCHARGED}>Alta</SelectItem>
-                <SelectItem value={PatientStatus.TRANSFERRED}>Transferido</SelectItem>
+                <SelectItem value={PatientStatus.HOSPITAL_DISCHARGE}>Alta Hospitalar</SelectItem>
+                <SelectItem value={PatientStatus.ADMINISTRATIVE_DISCHARGE}>Alta Administrativa</SelectItem>
+                <SelectItem value={PatientStatus.CANCELED}>Cancelado</SelectItem>
               </SelectContent>
             </Select>
           </div>
 
           <div>
             <label className="text-sm font-medium mb-2 block">Prioridade</label>
-            <Select onValueChange={(value) => onPriorityChange(value as PatientPriority | 'all')}>
+            <Select
+              value={currentPriority || 'all'}
+              onValueChange={(value) => onPriorityChange(value as PatientPriority | 'all')}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Todas as prioridades" />
               </SelectTrigger>

--- a/src/modules/patients/presentation/components/PatientList.tsx
+++ b/src/modules/patients/presentation/components/PatientList.tsx
@@ -6,7 +6,8 @@
 import { PatientCard } from './PatientCard';
 import { Patient } from '../../domain';
 import { Skeleton } from '@/shared/ui/skeleton';
-import { AlertCircle } from 'lucide-react';
+import { Button } from '@/shared/ui/button';
+import { AlertCircle, X } from 'lucide-react';
 import { Alert, AlertDescription } from '@/shared/ui/alert';
 
 interface PatientListProps {
@@ -15,6 +16,8 @@ interface PatientListProps {
   isError: boolean;
   error?: Error | null;
   onViewDetails: (id: string) => void;
+  hasActiveFilters?: boolean;
+  onClearFilters?: () => void;
 }
 
 export function PatientList({ 
@@ -22,7 +25,9 @@ export function PatientList({
   isLoading, 
   isError, 
   error,
-  onViewDetails 
+  onViewDetails,
+  hasActiveFilters,
+  onClearFilters
 }: PatientListProps) {
   // Loading State
   if (isLoading) {
@@ -52,14 +57,23 @@ export function PatientList({
   // Empty State
   if (patients.length === 0) {
     return (
-      <div className="text-center py-12">
+      <div className="text-center py-12 flex flex-col items-center">
         <div className="mx-auto w-16 h-16 rounded-full bg-muted flex items-center justify-center mb-4">
           <AlertCircle className="w-8 h-8 text-muted-foreground" />
         </div>
         <h3 className="text-lg font-semibold mb-2">Nenhum paciente encontrado</h3>
-        <p className="text-muted-foreground">
-          Ajuste os filtros ou cadastre um novo paciente
+        <p className="text-muted-foreground mb-6 max-w-sm mx-auto">
+          {hasActiveFilters
+            ? 'Não encontramos pacientes com os filtros selecionados. Tente ajustar a busca.'
+            : 'Não há pacientes cadastrados no momento.'}
         </p>
+
+        {hasActiveFilters && onClearFilters && (
+          <Button onClick={onClearFilters} variant="outline" className="gap-2">
+            <X className="h-4 w-4" />
+            Limpar Filtros
+          </Button>
+        )}
       </div>
     );
   }

--- a/src/modules/patients/presentation/pages/PatientsPage.tsx
+++ b/src/modules/patients/presentation/pages/PatientsPage.tsx
@@ -46,6 +46,15 @@ export function PatientsPage() {
     }));
   };
 
+  const handleClearFilters = () => {
+    setFilters({
+      page: 1,
+      pageSize: 20,
+    });
+  };
+
+  const hasActiveFilters = !!(filters.search || filters.status || filters.priority);
+
   const handleViewDetails = (id: string) => {
     // TODO: Navegar para página de detalhes ou abrir modal
     console.log('Ver detalhes do paciente:', id);
@@ -95,6 +104,9 @@ export function PatientsPage() {
         </CardHeader>
         <CardContent>
           <PatientFilters
+            currentSearch={filters.search}
+            currentStatus={filters.status}
+            currentPriority={filters.priority}
             onSearchChange={handleSearchChange}
             onStatusChange={handleStatusChange}
             onPriorityChange={handlePriorityChange}
@@ -109,6 +121,23 @@ export function PatientsPage() {
             <CardTitle>Lista de Pacientes</CardTitle>
             {data?.pagination && (
               <span className="text-sm text-muted-foreground">
+                {data.pagination.total} paciente{data.pagination.total !== 1 ? 's' : ''} encontrado{data.pagination.total !== 1 ? 's' : ''}
+              </span>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          <PatientList
+            patients={data?.data || []}
+            isLoading={isLoading}
+            isError={isError}
+            error={error}
+            onViewDetails={handleViewDetails}
+            hasActiveFilters={hasActiveFilters}
+            onClearFilters={handleClearFilters}
+          />
+        </CardContent>
+      </Card>
 
       {/* Modal do Formulário de Cadastro */}
       <Dialog open={isFormOpen} onOpenChange={setIsFormOpen}>
@@ -129,21 +158,6 @@ export function PatientsPage() {
           </ScrollArea>
         </DialogContent>
       </Dialog>
-                {data.pagination.total} paciente{data.pagination.total !== 1 ? 's' : ''} encontrado{data.pagination.total !== 1 ? 's' : ''}
-              </span>
-            )}
-          </div>
-        </CardHeader>
-        <CardContent>
-          <PatientList
-            patients={data?.data || []}
-            isLoading={isLoading}
-            isError={isError}
-            error={error}
-            onViewDetails={handleViewDetails}
-          />
-        </CardContent>
-      </Card>
     </div>
   );
 }


### PR DESCRIPTION
This PR improves the UX of the Patient List by adding an actionable empty state. When a user filters the list (via search, status, or priority) and no results are found, a "Clear Filters" button is now displayed directly in the empty state view.

Changes:
- `PatientList.tsx`: Added `hasActiveFilters` and `onClearFilters` props to conditionally render the button.
- `PatientFilters.tsx`: Refactored to be a controlled component (accepting `currentSearch`, etc.) and fixed incorrect Enum values for `PatientStatus`.
- `PatientsPage.tsx`: Wired up the state management to pass filter values and reset handlers.
- Added UX learning to `.jules/palette.md`.

---
*PR created automatically by Jules for task [6822530061125857912](https://jules.google.com/task/6822530061125857912) started by @mateuscarlos*