### PR TITLE
🎨 Palette: Add Actionable Empty States to Patient List

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,7 @@
 ## 2025-01-26 - Icon-Only Button Accessibility
 **Learning:** Icon-only buttons are invisible to screen readers without labels. Tooltips alone are insufficient for AT users.
 **Action:** Pair `Tooltip` (for sighted users) with `aria-label` (for AT users) on every icon button.
+
+## 2025-01-26 - Actionable Empty States
+**Learning:** Empty states (e.g. "No results found") are dead ends if they don't provide a way out.
+**Action:** When a list is empty due to filters, always provide a direct "Clear Filters" button in the empty state component.

--- a/src/modules/patients/presentation/components/PatientFilters.tsx
+++ b/src/modules/patients/presentation/components/PatientFilters.tsx
@@ -22,26 +22,25 @@ import {
 import { PatientStatus, PatientPriority } from '../../domain';
 
 interface PatientFiltersProps {
+  searchValue: string;
+  statusValue: PatientStatus | 'all';
+  priorityValue: PatientPriority | 'all';
   onSearchChange: (search: string) => void;
   onStatusChange: (status: PatientStatus | 'all') => void;
   onPriorityChange: (priority: PatientPriority | 'all') => void;
 }
 
 export function PatientFilters({
+  searchValue,
+  statusValue,
+  priorityValue,
   onSearchChange,
   onStatusChange,
   onPriorityChange,
 }: PatientFiltersProps) {
-  const [search, setSearch] = useState('');
   const [showFilters, setShowFilters] = useState(false);
 
-  const handleSearchChange = (value: string) => {
-    setSearch(value);
-    onSearchChange(value);
-  };
-
   const handleClearSearch = () => {
-    setSearch('');
     onSearchChange('');
   };
 
@@ -58,10 +57,10 @@ export function PatientFilters({
             aria-label="Buscar pacientes"
             placeholder="Buscar por nome, prontuário ou CPF..."
             className="pl-9 pr-9 [&::-webkit-search-cancel-button]:hidden"
-            value={search}
-            onChange={(e) => handleSearchChange(e.target.value)}
+            value={searchValue}
+            onChange={(e) => onSearchChange(e.target.value)}
           />
-          {search && (
+          {searchValue && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
@@ -107,7 +106,10 @@ export function PatientFilters({
         >
           <div>
             <label className="text-sm font-medium mb-2 block">Status</label>
-            <Select onValueChange={(value) => onStatusChange(value as PatientStatus | 'all')}>
+            <Select
+              value={statusValue}
+              onValueChange={(value) => onStatusChange(value as PatientStatus | 'all')}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Todos os status" />
               </SelectTrigger>
@@ -123,7 +125,10 @@ export function PatientFilters({
 
           <div>
             <label className="text-sm font-medium mb-2 block">Prioridade</label>
-            <Select onValueChange={(value) => onPriorityChange(value as PatientPriority | 'all')}>
+            <Select
+              value={priorityValue}
+              onValueChange={(value) => onPriorityChange(value as PatientPriority | 'all')}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Todas as prioridades" />
               </SelectTrigger>

--- a/src/modules/patients/presentation/components/PatientList.tsx
+++ b/src/modules/patients/presentation/components/PatientList.tsx
@@ -8,6 +8,7 @@ import { Patient } from '../../domain';
 import { Skeleton } from '@/shared/ui/skeleton';
 import { AlertCircle } from 'lucide-react';
 import { Alert, AlertDescription } from '@/shared/ui/alert';
+import { Button } from '@/shared/ui/button';
 
 interface PatientListProps {
   patients: Patient[];
@@ -15,6 +16,8 @@ interface PatientListProps {
   isError: boolean;
   error?: Error | null;
   onViewDetails: (id: string) => void;
+  hasActiveFilters?: boolean;
+  onClearFilters?: () => void;
 }
 
 export function PatientList({ 
@@ -22,7 +25,9 @@ export function PatientList({
   isLoading, 
   isError, 
   error,
-  onViewDetails 
+  onViewDetails,
+  hasActiveFilters,
+  onClearFilters
 }: PatientListProps) {
   // Loading State
   if (isLoading) {
@@ -57,9 +62,16 @@ export function PatientList({
           <AlertCircle className="w-8 h-8 text-muted-foreground" />
         </div>
         <h3 className="text-lg font-semibold mb-2">Nenhum paciente encontrado</h3>
-        <p className="text-muted-foreground">
-          Ajuste os filtros ou cadastre um novo paciente
+        <p className="text-muted-foreground mb-4">
+          {hasActiveFilters
+            ? "Não encontramos pacientes com os filtros atuais."
+            : "Comece cadastrando um novo paciente."}
         </p>
+        {hasActiveFilters && onClearFilters && (
+          <Button variant="outline" onClick={onClearFilters}>
+            Limpar filtros
+          </Button>
+        )}
       </div>
     );
   }

--- a/src/modules/patients/presentation/pages/PatientsPage.tsx
+++ b/src/modules/patients/presentation/pages/PatientsPage.tsx
@@ -46,6 +46,12 @@ export function PatientsPage() {
     }));
   };
 
+  const handleClearFilters = () => {
+    setFilters({ page: 1, pageSize: 20 });
+  };
+
+  const hasActiveFilters = !!(filters.search || filters.status || filters.priority);
+
   const handleViewDetails = (id: string) => {
     // TODO: Navegar para página de detalhes ou abrir modal
     console.log('Ver detalhes do paciente:', id);
@@ -95,6 +101,9 @@ export function PatientsPage() {
         </CardHeader>
         <CardContent>
           <PatientFilters
+            searchValue={filters.search || ''}
+            statusValue={filters.status || 'all'}
+            priorityValue={filters.priority || 'all'}
             onSearchChange={handleSearchChange}
             onStatusChange={handleStatusChange}
             onPriorityChange={handlePriorityChange}
@@ -141,6 +150,8 @@ export function PatientsPage() {
             isError={isError}
             error={error}
             onViewDetails={handleViewDetails}
+            hasActiveFilters={hasActiveFilters}
+            onClearFilters={handleClearFilters}
           />
         </CardContent>
       </Card>


### PR DESCRIPTION
*   💡 What: Added a "Clear Filters" button to the empty state when no patients match the current filters.
*   🎯 Why: Users were hitting a dead end when filters returned no results, requiring them to manually find and reset filters.
*   📸 Before: Just text "Ajuste os filtros ou cadastre um novo paciente".
*   📸 After: Text "Não encontramos pacientes com os filtros atuais" and a button "Limpar filtros".
*   ♿ Accessibility: The button is keyboard accessible and provides a clear path forward.
*   Related: Refactored `PatientFilters` to be a controlled component to enable this feature.

---
*PR created automatically by Jules for task [9779713888574209946](https://jules.google.com/task/9779713888574209946) started by @mateuscarlos*