### PR TITLE
🎨 Palette: Add 'Clear Filters' action to empty state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,7 @@
 ## 2025-01-26 - Icon-Only Button Accessibility
 **Learning:** Icon-only buttons are invisible to screen readers without labels. Tooltips alone are insufficient for AT users.
 **Action:** Pair `Tooltip` (for sighted users) with `aria-label` (for AT users) on every icon button.
+
+## 2025-01-26 - Actionable Empty States
+**Learning:** Users often get stuck in empty states caused by filters. A static message isn't enough to help them recover.
+**Action:** Always include a "Clear Filters" action in empty states when filters are active, and ensure filter components are controlled to support this reset.

--- a/src/modules/patients/presentation/components/PatientFilters.tsx
+++ b/src/modules/patients/presentation/components/PatientFilters.tsx
@@ -22,26 +22,29 @@ import {
 import { PatientStatus, PatientPriority } from '../../domain';
 
 interface PatientFiltersProps {
+  searchValue?: string;
+  statusValue?: PatientStatus | 'all';
+  priorityValue?: PatientPriority | 'all';
   onSearchChange: (search: string) => void;
   onStatusChange: (status: PatientStatus | 'all') => void;
   onPriorityChange: (priority: PatientPriority | 'all') => void;
 }
 
 export function PatientFilters({
+  searchValue = '',
+  statusValue = 'all',
+  priorityValue = 'all',
   onSearchChange,
   onStatusChange,
   onPriorityChange,
 }: PatientFiltersProps) {
-  const [search, setSearch] = useState('');
   const [showFilters, setShowFilters] = useState(false);
 
   const handleSearchChange = (value: string) => {
-    setSearch(value);
     onSearchChange(value);
   };
 
   const handleClearSearch = () => {
-    setSearch('');
     onSearchChange('');
   };
 
@@ -58,10 +61,10 @@ export function PatientFilters({
             aria-label="Buscar pacientes"
             placeholder="Buscar por nome, prontuário ou CPF..."
             className="pl-9 pr-9 [&::-webkit-search-cancel-button]:hidden"
-            value={search}
+            value={searchValue}
             onChange={(e) => handleSearchChange(e.target.value)}
           />
-          {search && (
+          {searchValue && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
@@ -107,7 +110,10 @@ export function PatientFilters({
         >
           <div>
             <label className="text-sm font-medium mb-2 block">Status</label>
-            <Select onValueChange={(value) => onStatusChange(value as PatientStatus | 'all')}>
+            <Select
+              value={statusValue}
+              onValueChange={(value) => onStatusChange(value as PatientStatus | 'all')}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Todos os status" />
               </SelectTrigger>
@@ -123,7 +129,10 @@ export function PatientFilters({
 
           <div>
             <label className="text-sm font-medium mb-2 block">Prioridade</label>
-            <Select onValueChange={(value) => onPriorityChange(value as PatientPriority | 'all')}>
+            <Select
+              value={priorityValue}
+              onValueChange={(value) => onPriorityChange(value as PatientPriority | 'all')}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Todas as prioridades" />
               </SelectTrigger>

--- a/src/modules/patients/presentation/components/PatientList.tsx
+++ b/src/modules/patients/presentation/components/PatientList.tsx
@@ -8,13 +8,16 @@ import { Patient } from '../../domain';
 import { Skeleton } from '@/shared/ui/skeleton';
 import { AlertCircle } from 'lucide-react';
 import { Alert, AlertDescription } from '@/shared/ui/alert';
+import { Button } from '@/shared/ui/button';
 
 interface PatientListProps {
   patients: Patient[];
   isLoading: boolean;
   isError: boolean;
   error?: Error | null;
+  hasActiveFilters?: boolean;
   onViewDetails: (id: string) => void;
+  onClearFilters?: () => void;
 }
 
 export function PatientList({ 
@@ -22,7 +25,9 @@ export function PatientList({
   isLoading, 
   isError, 
   error,
-  onViewDetails 
+  hasActiveFilters,
+  onViewDetails,
+  onClearFilters
 }: PatientListProps) {
   // Loading State
   if (isLoading) {
@@ -56,10 +61,19 @@ export function PatientList({
         <div className="mx-auto w-16 h-16 rounded-full bg-muted flex items-center justify-center mb-4">
           <AlertCircle className="w-8 h-8 text-muted-foreground" />
         </div>
-        <h3 className="text-lg font-semibold mb-2">Nenhum paciente encontrado</h3>
-        <p className="text-muted-foreground">
-          Ajuste os filtros ou cadastre um novo paciente
+        <h3 className="text-lg font-semibold mb-2">
+          {hasActiveFilters ? 'Nenhum paciente encontrado com os filtros atuais' : 'Nenhum paciente encontrado'}
+        </h3>
+        <p className="text-muted-foreground mb-4">
+          {hasActiveFilters
+            ? 'Tente ajustar os filtros ou limpar a busca'
+            : 'Cadastre um novo paciente para começar'}
         </p>
+        {hasActiveFilters && onClearFilters && (
+          <Button variant="outline" onClick={onClearFilters}>
+            Limpar Filtros
+          </Button>
+        )}
       </div>
     );
   }

--- a/src/modules/patients/presentation/pages/PatientsPage.tsx
+++ b/src/modules/patients/presentation/pages/PatientsPage.tsx
@@ -46,6 +46,15 @@ export function PatientsPage() {
     }));
   };
 
+  const handleClearFilters = () => {
+    setFilters({
+      page: 1,
+      pageSize: 20,
+    });
+  };
+
+  const hasActiveFilters = !!(filters.search || filters.status || filters.priority);
+
   const handleViewDetails = (id: string) => {
     // TODO: Navegar para página de detalhes ou abrir modal
     console.log('Ver detalhes do paciente:', id);
@@ -95,6 +104,9 @@ export function PatientsPage() {
         </CardHeader>
         <CardContent>
           <PatientFilters
+            searchValue={filters.search}
+            statusValue={filters.status || 'all'}
+            priorityValue={filters.priority || 'all'}
             onSearchChange={handleSearchChange}
             onStatusChange={handleStatusChange}
             onPriorityChange={handlePriorityChange}
@@ -140,7 +152,9 @@ export function PatientsPage() {
             isLoading={isLoading}
             isError={isError}
             error={error}
+            hasActiveFilters={hasActiveFilters}
             onViewDetails={handleViewDetails}
+            onClearFilters={handleClearFilters}
           />
         </CardContent>
       </Card>


### PR DESCRIPTION
💡 What: Added a "Clear Filters" button to the patient list empty state when filters are active, and refactored `PatientFilters` to be a controlled component.
🎯 Why: Users could get stuck in an empty state after applying filters. A clear action helps them recover quickly.
♿ Accessibility: Button has clear text, search input remains accessible.


---
*PR created automatically by Jules for task [10678870124778248387](https://jules.google.com/task/10678870124778248387) started by @mateuscarlos*