### PR TITLE
🎨 Palette: Add debounce to patient search filter

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,7 @@
 ## 2025-01-26 - Icon-Only Button Accessibility
 **Learning:** Icon-only buttons are invisible to screen readers without labels. Tooltips alone are insufficient for AT users.
 **Action:** Pair `Tooltip` (for sighted users) with `aria-label` (for AT users) on every icon button.
+
+## 2025-01-26 - Debounce for Instant Search
+**Learning:** Real-time search inputs without debounce cause excessive API calls and "skeleton flashing" even with local mock data, degrading perceived performance.
+**Action:** Implement a generic `useDebounce` hook for all search inputs to smooth out interactions and reduce server load.

--- a/src/modules/patients/presentation/components/PatientFilters.tsx
+++ b/src/modules/patients/presentation/components/PatientFilters.tsx
@@ -3,9 +3,10 @@
  * Barra de filtros e busca de pacientes
  */
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Input } from '@/shared/ui/input';
 import { Button } from '@/shared/ui/button';
+import { useDebounce } from '@/shared/hooks';
 import { Search, Filter, X } from 'lucide-react';
 import {
   Tooltip,
@@ -34,15 +35,18 @@ export function PatientFilters({
 }: PatientFiltersProps) {
   const [search, setSearch] = useState('');
   const [showFilters, setShowFilters] = useState(false);
+  const debouncedSearch = useDebounce(search, 500);
+
+  useEffect(() => {
+    onSearchChange(debouncedSearch);
+  }, [debouncedSearch, onSearchChange]);
 
   const handleSearchChange = (value: string) => {
     setSearch(value);
-    onSearchChange(value);
   };
 
   const handleClearSearch = () => {
     setSearch('');
-    onSearchChange('');
   };
 
   return (

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -2,3 +2,4 @@
 export * from './use-toast';
 export * from './use-mobile';
 export * from './useViaCep';
+export * from './use-debounce';

--- a/src/shared/hooks/use-debounce.ts
+++ b/src/shared/hooks/use-debounce.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
💡 What: Implemented a `useDebounce` hook and applied it to the patient search filter.
🎯 Why: Prevents excessive API calls and UI flickering (skeleton loading) during rapid typing.
♿ Accessibility: Improves perceived performance and stability for all users.

---
*PR created automatically by Jules for task [1062888251771704650](https://jules.google.com/task/1062888251771704650) started by @mateuscarlos*