### PR TITLE
🛡️ Sentinel: [MEDIUM] Sanitize sensitive data in API logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `.env` file containing environment variables (potentially secrets) was tracked in the git repository.
 **Learning:** Initial project setup or template generation failed to include `.env` in `.gitignore`, leading to accidental tracking of local configuration.
 **Prevention:** Always verify `.gitignore` includes sensitive file patterns (`.env`, `*.pem`, etc.) before the first commit. Use pre-commit hooks to scan for secrets.
+
+## 2026-03-05 - Centralized Data Sanitization
+**Vulnerability:** API request/response interceptors were logging full payloads, including passwords and tokens, in debug mode.
+**Learning:** Debug logging often bypasses security checks if not explicitly designed with sanitization in mind. A centralized helper (`sanitizeData`) ensures consistent masking across all log sources.
+**Prevention:** Implement a recursive sanitization utility at the start of the project and enforce its use in all logging layers (interceptors, middleware, error handlers).

--- a/src/core/config/api.config.ts
+++ b/src/core/config/api.config.ts
@@ -5,6 +5,7 @@
 
 import axios, { AxiosError, AxiosInstance, InternalAxiosRequestConfig, AxiosResponse } from 'axios';
 import { ENV } from './env.config';
+import { sanitizeData } from '@/core/lib/security';
 
 // Criar instância do Axios
 export const apiClient: AxiosInstance = axios.create({
@@ -32,7 +33,7 @@ apiClient.interceptors.request.use(
       console.log('🚀 API Request:', {
         method: config.method?.toUpperCase(),
         url: config.url,
-        data: config.data,
+        data: sanitizeData(config.data),
       });
     }
 
@@ -55,7 +56,7 @@ apiClient.interceptors.response.use(
       console.log('✅ API Response:', {
         status: response.status,
         url: response.config.url,
-        data: response.data,
+        data: sanitizeData(response.data),
       });
     }
 

--- a/src/core/lib/index.ts
+++ b/src/core/lib/index.ts
@@ -2,3 +2,4 @@
 export * from './query-client';
 export * from './validators';
 export * from './formatters';
+export * from './security';

--- a/src/core/lib/security.ts
+++ b/src/core/lib/security.ts
@@ -1,0 +1,49 @@
+/**
+ * Security Utilities
+ * Common security functions for data sanitization and protection
+ */
+
+// Keys that should be masked in logs
+const SENSITIVE_KEYS = [
+  'password',
+  'token',
+  'access_token',
+  'refresh_token',
+  'authorization',
+  'secret',
+  'key',
+  'credit_card',
+  'cvv',
+];
+
+/**
+ * Sanitizes an object by masking sensitive values
+ * Useful for logging safely
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function sanitizeData(data: any): any {
+  if (!data) return data;
+
+  if (Array.isArray(data)) {
+    return data.map(item => sanitizeData(item));
+  }
+
+  if (typeof data === 'object') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sanitized: any = { ...data };
+
+    for (const key of Object.keys(sanitized)) {
+      const lowerKey = key.toLowerCase();
+
+      if (SENSITIVE_KEYS.some(sensitive => lowerKey.includes(sensitive))) {
+        sanitized[key] = '***MASKED***';
+      } else if (typeof sanitized[key] === 'object') {
+        sanitized[key] = sanitizeData(sanitized[key]);
+      }
+    }
+
+    return sanitized;
+  }
+
+  return data;
+}


### PR DESCRIPTION
Implemented `sanitizeData` utility to mask sensitive keys (password, token, etc.) in API request and response logs. This prevents credential leakage during development or debug sessions.

**Changes:**
- Created `src/core/lib/security.ts` with `sanitizeData` function.
- Updated `src/core/lib/index.ts` to export the new module.
- integrated `sanitizeData` into `src/core/config/api.config.ts` interceptors.
- Added journal entry in `.jules/sentinel.md`.

**Verification:**
- Verified with a temporary script that keys like `password` and `token` are masked.
- Ran `pnpm lint` and `pnpm build` successfully.

---
*PR created automatically by Jules for task [16925310802108686021](https://jules.google.com/task/16925310802108686021) started by @mateuscarlos*