### PR TITLE
🎨 Palette: Add loading state to Button component

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-12 - Standardized Button Loading State
+**Learning:** Adding an `isLoading` prop to Shadcn UI `Button` component simplifies usage across the app but requires careful handling of `asChild`. When `asChild` is true (e.g., used with `Link`), injecting a spinner automatically is unsafe due to `Slot` expecting a single child.
+**Action:** Always check `asChild` before injecting content into `Slot`-based components. For icon-only buttons, the consumer must manually hide the icon when loading to prevent layout breakage.

--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -6,7 +6,7 @@
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
-import { Loader2, Search } from 'lucide-react';
+import { Search } from 'lucide-react';
 
 import { PatientFormData, patientFormSchema } from '../forms/PatientFormSchema';
 import { PatientStatus } from '@/modules/patients/domain/Patient.entity';
@@ -220,13 +220,9 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                     variant="outline"
                     size="icon"
                     onClick={handleFetchAddress}
-                    disabled={loadingCep}
+                    isLoading={loadingCep}
                   >
-                    {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Search className="h-4 w-4" />
-                    )}
+                    {!loadingCep && <Search className="h-4 w-4" />}
                   </Button>
                 </div>
                 {errors.zipCode && (
@@ -567,16 +563,9 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
           <Button
             type="button"
             onClick={handleConfirmSave}
-            disabled={isSubmitting}
+            isLoading={isSubmitting}
           >
-            {isSubmitting ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Salvando...
-              </>
-            ) : (
-              'Salvar'
-            )}
+            {isSubmitting ? 'Salvando...' : 'Salvar'}
           </Button>
         </div>
       </form>

--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import { Loader2 } from "lucide-react";
 
 import { cn } from "@/shared/utils/cn";
 
@@ -37,17 +38,36 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  isLoading?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, asChild = false, isLoading = false, children, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
+
+    if (asChild) {
+      return (
+        <Comp
+          className={cn(buttonVariants({ variant, size, className }))}
+          ref={ref}
+          disabled={isLoading || props.disabled}
+          {...props}
+        >
+          {children}
+        </Comp>
+      );
+    }
+
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
+        disabled={isLoading || props.disabled}
         {...props}
-      />
+      >
+        {isLoading && <Loader2 className={cn("h-4 w-4 animate-spin", children ? "mr-2" : "")} />}
+        {children}
+      </Comp>
     );
   },
 );


### PR DESCRIPTION
Added `isLoading` prop to Shadcn UI `Button` component to standardize loading states across the application. Also refactored `PatientForm` to use this new prop, simplifying the code. Confirmed that `asChild` prop is handled correctly to avoid React errors with `Slot`. verified visually with Playwright.

---
*PR created automatically by Jules for task [765030472179224338](https://jules.google.com/task/765030472179224338) started by @mateuscarlos*