### PR TITLE
⚡ Bolt: Memoize PatientCard to prevent unnecessary re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-02-18 - Nested Suspense for Layouts
 **Learning:** Placing a `Suspense` boundary inside the Layout component (wrapping `Outlet`) instead of just at the top level allows the sidebar/header to remain visible while the page content loads.
 **Action:** Identify Layout components and wrap their `Outlet` in `Suspense` to avoid "white screen" flashes during navigation.
+
+## 2025-02-18 - Memoization of List Items with Callback Props
+**Learning:** List components (like `PatientList`) re-render all children when parent state changes (e.g. modal open) if children (`PatientCard`) are not memoized AND if callback props (`onViewDetails`) are not stable. Both `React.memo` on the child and `useCallback` on the parent handler are required to prevent this.
+**Action:** When optimizing lists, always check that handlers passed to memoized children are wrapped in `useCallback`.

--- a/src/modules/patients/presentation/components/PatientCard.tsx
+++ b/src/modules/patients/presentation/components/PatientCard.tsx
@@ -3,6 +3,7 @@
  * Exibe informações resumidas de um paciente em formato de card
  */
 
+import { memo } from 'react';
 import { Card, CardContent } from '@/shared/ui/card';
 import { Badge } from '@/shared/ui/badge';
 import { Button } from '@/shared/ui/button';
@@ -16,7 +17,8 @@ interface PatientCardProps {
   onViewDetails: (id: string) => void;
 }
 
-export function PatientCard({ patient, onViewDetails }: PatientCardProps) {
+// Memoized to prevent re-renders when parent state changes
+export const PatientCard = memo(function PatientCard({ patient, onViewDetails }: PatientCardProps) {
   const age = PatientValidator.calculateAge(patient.birthDate);
   
   return (
@@ -100,4 +102,4 @@ export function PatientCard({ patient, onViewDetails }: PatientCardProps) {
       </CardContent>
     </Card>
   );
-}
+});

--- a/src/modules/patients/presentation/pages/PatientsPage.tsx
+++ b/src/modules/patients/presentation/pages/PatientsPage.tsx
@@ -4,7 +4,7 @@
  * Arquitetura modular: separação de domínio, dados e apresentação
  */
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
@@ -46,10 +46,11 @@ export function PatientsPage() {
     }));
   };
 
-  const handleViewDetails = (id: string) => {
+  // Memoized to prevent unnecessary re-renders in PatientList
+  const handleViewDetails = useCallback((id: string) => {
     // TODO: Navegar para página de detalhes ou abrir modal
     console.log('Ver detalhes do paciente:', id);
-  };
+  }, []);
 
   const handleCreatePatient = () => {
     setIsFormOpen(true);


### PR DESCRIPTION
💡 What: Memoized `PatientCard` component using `React.memo` and wrapped `handleViewDetails` in `useCallback` in `PatientsPage`.
🎯 Why: Opening the "New Patient" modal caused the entire list of patients to re-render, even though the data didn't change. This was due to `PatientCard` not being memoized and `handleViewDetails` being recreated on every render.
📊 Impact: Reduced re-renders of `PatientCard` from N to 0 when opening the modal (where N is the number of patients). Verified with a script counting render logs.
🔬 Measurement: Verified using a custom Playwright script that counted console logs during interaction.

---
*PR created automatically by Jules for task [1746807835717785723](https://jules.google.com/task/1746807835717785723) started by @mateuscarlos*