### PR TITLE
🎨 Palette: Add tooltip and aria-label to CEP search button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Icon-Only Buttons Accessibility
+**Learning:** Icon-only buttons (like search) often lack `aria-label` and explanatory tooltips, making them inaccessible to screen readers and potentially confusing for users.
+**Action:** Always wrap icon-only buttons in a `Tooltip` component and add a descriptive `aria-label` to the button element.

--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -20,6 +20,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Textarea } from '@/shared/ui/textarea';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card';
 import { useToast } from '@/shared/hooks/use-toast';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
 
 interface PatientFormProps {
   onSubmit: (data: PatientFormData) => void;
@@ -215,19 +216,27 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                       setValue('zipCode', unmaskCEP(masked));
                     }}
                   />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    onClick={handleFetchAddress}
-                    disabled={loadingCep}
-                  >
-                    {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Search className="h-4 w-4" />
-                    )}
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={handleFetchAddress}
+                        disabled={loadingCep}
+                        aria-label="Buscar endereço pelo CEP"
+                      >
+                        {loadingCep ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Search className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Buscar endereço pelo CEP</p>
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 {errors.zipCode && (
                   <p className="text-sm text-destructive">{errors.zipCode.message}</p>


### PR DESCRIPTION
💡 **What:** Added a tooltip ("Buscar endereço pelo CEP") and an `aria-label` to the CEP search button in the Patient Form.
🎯 **Why:** The button was icon-only, making it inaccessible to screen readers and potentially confusing for sighted users who might not understand the icon's purpose immediately.
📸 **Before/After:**
*   *Before:* Icon-only button.
*   *After:* Button with tooltip on hover and screen reader support.
♿ **Accessibility:**
*   Added `aria-label="Buscar endereço pelo CEP"`.
*   Added visual tooltip for mouse/keyboard users.

---
*PR created automatically by Jules for task [10261839860018501773](https://jules.google.com/task/10261839860018501773) started by @mateuscarlos*