### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix sensitive data exposure in logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `.env` file containing environment variables (potentially secrets) was tracked in the git repository.
 **Learning:** Initial project setup or template generation failed to include `.env` in `.gitignore`, leading to accidental tracking of local configuration.
 **Prevention:** Always verify `.gitignore` includes sensitive file patterns (`.env`, `*.pem`, etc.) before the first commit. Use pre-commit hooks to scan for secrets.
+
+## 2026-02-01 - Sensitive Data Exposure in Debug Logs
+**Vulnerability:** The API client configuration (`api.config.ts`) was logging full request/response bodies to the console in development mode, exposing sensitive user data (passwords, tokens) in plain text.
+**Learning:** Default debug configurations often prioritize visibility over security. The `ENV.ENABLE_DEBUG` flag enabled verbose logging without sanitization, creating a risk of accidental data leakage during debugging sessions or screen sharing.
+**Prevention:** Implement a centralized `sanitizeData` utility that recursively masks known sensitive keys (e.g., 'password', 'token') before any logging operation. Ensure this utility is applied to all logger instances.

--- a/src/core/config/api.config.ts
+++ b/src/core/config/api.config.ts
@@ -5,6 +5,7 @@
 
 import axios, { AxiosError, AxiosInstance, InternalAxiosRequestConfig, AxiosResponse } from 'axios';
 import { ENV } from './env.config';
+import { sanitizeData } from '../lib/security';
 
 // Criar instância do Axios
 export const apiClient: AxiosInstance = axios.create({
@@ -32,7 +33,7 @@ apiClient.interceptors.request.use(
       console.log('🚀 API Request:', {
         method: config.method?.toUpperCase(),
         url: config.url,
-        data: config.data,
+        data: sanitizeData(config.data),
       });
     }
 
@@ -55,7 +56,7 @@ apiClient.interceptors.response.use(
       console.log('✅ API Response:', {
         status: response.status,
         url: response.config.url,
-        data: response.data,
+        data: sanitizeData(response.data),
       });
     }
 

--- a/src/core/lib/index.ts
+++ b/src/core/lib/index.ts
@@ -2,3 +2,4 @@
 export * from './query-client';
 export * from './validators';
 export * from './formatters';
+export * from './security';

--- a/src/core/lib/security.ts
+++ b/src/core/lib/security.ts
@@ -1,0 +1,62 @@
+/**
+ * Security Utilities
+ * Helper functions for data sanitization and security checks
+ */
+
+// List of sensitive keys that should be masked in logs
+// Case insensitive matching will be applied
+const SENSITIVE_KEYS = [
+  'password',
+  'passwordConfirm',
+  'token',
+  'accessToken',
+  'refreshToken',
+  'secret',
+  'authorization',
+  'cookie',
+  'creditCard',
+  'cvv',
+  'apiKey',
+];
+
+/**
+ * Sanitizes data by masking sensitive fields
+ * recursive function to handle nested objects and arrays
+ * @param data - The data to sanitize
+ * @returns The sanitized data
+ */
+export function sanitizeData(data: unknown): unknown {
+  if (!data) return data;
+
+  if (Array.isArray(data)) {
+    return data.map(item => sanitizeData(item));
+  }
+
+  if (typeof data === 'object' && data !== null) {
+    // Avoid sanitizing special objects like Date, RegExp, etc. if they are not plain objects
+    // But for logging purposes, JSON compatibility is main concern.
+    // However, if we receive a class instance, spreading it might lose prototype or private fields.
+    // For logging, we usually want a plain object representation.
+
+    // Check if it's a plain object or something that behaves like one
+    const sanitized: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(data)) {
+      // Check if key is sensitive (case insensitive partial match)
+      // e.g. "userPassword", "api_token", "MySecret"
+      const isSensitive = SENSITIVE_KEYS.some(sensitiveKey =>
+        key.toLowerCase().includes(sensitiveKey.toLowerCase())
+      );
+
+      if (isSensitive) {
+        sanitized[key] = '***MASKED***';
+      } else {
+        sanitized[key] = sanitizeData(value);
+      }
+    }
+
+    return sanitized;
+  }
+
+  return data;
+}


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix sensitive data exposure in logs

🚨 Severity: MEDIUM
💡 Vulnerability: API request and response bodies were being logged to the console in development mode without sanitization, potentially exposing passwords and tokens.
🎯 Impact: Accidental leakage of sensitive user credentials during debugging or screen sharing.
🔧 Fix: Implemented `sanitizeData` utility to recursively mask keys matching a sensitive list (e.g., 'password', 'token') and applied it to the API interceptor loggers.
✅ Verification: Verified using a standalone script `verify_sanitization.ts` (deleted before commit) which confirmed that sensitive fields are replaced with `***MASKED***`.

---
*PR created automatically by Jules for task [12032155177720626596](https://jules.google.com/task/12032155177720626596) started by @mateuscarlos*