### PR TITLE
🎨 Palette: Add actionable empty state to PatientList

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,7 @@
+## 2024-05-22 - Actionable Empty States
+**Learning:** Empty states in list views (like `PatientList`) are prime opportunities for "micro-UX" improvements. By distinguishing between "no data at all" and "no results found for filters", we can guide the user to the next logical action (create new vs clear filters). Implementing "Clear Filters" requires the filter components to be fully controlled by the parent page, often necessitating a refactor from uncontrolled local state to lifted state.
+**Action:** When encountering list views with filters, check if the empty state provides a way to reset filters. If not, plan to lift the filter state to the parent component and implement a "Clear Filters" action in the empty state.
+
+## 2024-05-22 - Local Mock Data
+**Learning:** This project supports a `VITE_ENABLE_MOCK_DATA=true` environment variable to run the frontend with mock data, bypassing the backend. This is crucial for verifying UI changes in isolation without needing a full backend setup.
+**Action:** Always check for `VITE_ENABLE_MOCK_DATA` support when working on frontend tasks to enable faster feedback loops.

--- a/src/modules/patients/presentation/components/PatientFilters.tsx
+++ b/src/modules/patients/presentation/components/PatientFilters.tsx
@@ -22,26 +22,29 @@ import {
 import { PatientStatus, PatientPriority } from '../../domain';
 
 interface PatientFiltersProps {
+  search?: string;
+  status?: PatientStatus | 'all';
+  priority?: PatientPriority | 'all';
   onSearchChange: (search: string) => void;
   onStatusChange: (status: PatientStatus | 'all') => void;
   onPriorityChange: (priority: PatientPriority | 'all') => void;
 }
 
 export function PatientFilters({
+  search = '',
+  status = 'all',
+  priority = 'all',
   onSearchChange,
   onStatusChange,
   onPriorityChange,
 }: PatientFiltersProps) {
-  const [search, setSearch] = useState('');
   const [showFilters, setShowFilters] = useState(false);
 
   const handleSearchChange = (value: string) => {
-    setSearch(value);
     onSearchChange(value);
   };
 
   const handleClearSearch = () => {
-    setSearch('');
     onSearchChange('');
   };
 
@@ -107,7 +110,10 @@ export function PatientFilters({
         >
           <div>
             <label className="text-sm font-medium mb-2 block">Status</label>
-            <Select onValueChange={(value) => onStatusChange(value as PatientStatus | 'all')}>
+            <Select
+              value={status}
+              onValueChange={(value) => onStatusChange(value as PatientStatus | 'all')}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Todos os status" />
               </SelectTrigger>
@@ -123,7 +129,10 @@ export function PatientFilters({
 
           <div>
             <label className="text-sm font-medium mb-2 block">Prioridade</label>
-            <Select onValueChange={(value) => onPriorityChange(value as PatientPriority | 'all')}>
+            <Select
+              value={priority}
+              onValueChange={(value) => onPriorityChange(value as PatientPriority | 'all')}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Todas as prioridades" />
               </SelectTrigger>

--- a/src/modules/patients/presentation/components/PatientList.tsx
+++ b/src/modules/patients/presentation/components/PatientList.tsx
@@ -8,6 +8,7 @@ import { Patient } from '../../domain';
 import { Skeleton } from '@/shared/ui/skeleton';
 import { AlertCircle } from 'lucide-react';
 import { Alert, AlertDescription } from '@/shared/ui/alert';
+import { Button } from '@/shared/ui/button';
 
 interface PatientListProps {
   patients: Patient[];
@@ -15,6 +16,8 @@ interface PatientListProps {
   isError: boolean;
   error?: Error | null;
   onViewDetails: (id: string) => void;
+  hasActiveFilters?: boolean;
+  onClearFilters?: () => void;
 }
 
 export function PatientList({ 
@@ -22,7 +25,9 @@ export function PatientList({
   isLoading, 
   isError, 
   error,
-  onViewDetails 
+  onViewDetails,
+  hasActiveFilters,
+  onClearFilters
 }: PatientListProps) {
   // Loading State
   if (isLoading) {
@@ -57,9 +62,17 @@ export function PatientList({
           <AlertCircle className="w-8 h-8 text-muted-foreground" />
         </div>
         <h3 className="text-lg font-semibold mb-2">Nenhum paciente encontrado</h3>
-        <p className="text-muted-foreground">
-          Ajuste os filtros ou cadastre um novo paciente
+        <p className="text-muted-foreground mb-6">
+          {hasActiveFilters
+            ? "Ajuste os filtros para encontrar o que procura."
+            : "Cadastre um novo paciente para começar."}
         </p>
+
+        {hasActiveFilters && onClearFilters && (
+          <Button variant="outline" onClick={onClearFilters}>
+            Limpar filtros
+          </Button>
+        )}
       </div>
     );
   }

--- a/src/modules/patients/presentation/pages/PatientsPage.tsx
+++ b/src/modules/patients/presentation/pages/PatientsPage.tsx
@@ -46,6 +46,13 @@ export function PatientsPage() {
     }));
   };
 
+  const handleClearFilters = () => {
+    setFilters({
+      page: 1,
+      pageSize: 20,
+    });
+  };
+
   const handleViewDetails = (id: string) => {
     // TODO: Navegar para página de detalhes ou abrir modal
     console.log('Ver detalhes do paciente:', id);
@@ -71,6 +78,8 @@ export function PatientsPage() {
     setIsFormOpen(false);
   };
 
+  const hasActiveFilters = !!(filters.search || filters.status || filters.priority);
+
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -95,6 +104,9 @@ export function PatientsPage() {
         </CardHeader>
         <CardContent>
           <PatientFilters
+            search={filters.search}
+            status={filters.status}
+            priority={filters.priority}
             onSearchChange={handleSearchChange}
             onStatusChange={handleStatusChange}
             onPriorityChange={handlePriorityChange}
@@ -109,6 +121,23 @@ export function PatientsPage() {
             <CardTitle>Lista de Pacientes</CardTitle>
             {data?.pagination && (
               <span className="text-sm text-muted-foreground">
+                {data.pagination.total} paciente{data.pagination.total !== 1 ? 's' : ''} encontrado{data.pagination.total !== 1 ? 's' : ''}
+              </span>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          <PatientList
+            patients={data?.data || []}
+            isLoading={isLoading}
+            isError={isError}
+            error={error}
+            onViewDetails={handleViewDetails}
+            hasActiveFilters={hasActiveFilters}
+            onClearFilters={handleClearFilters}
+          />
+        </CardContent>
+      </Card>
 
       {/* Modal do Formulário de Cadastro */}
       <Dialog open={isFormOpen} onOpenChange={setIsFormOpen}>
@@ -129,21 +158,6 @@ export function PatientsPage() {
           </ScrollArea>
         </DialogContent>
       </Dialog>
-                {data.pagination.total} paciente{data.pagination.total !== 1 ? 's' : ''} encontrado{data.pagination.total !== 1 ? 's' : ''}
-              </span>
-            )}
-          </div>
-        </CardHeader>
-        <CardContent>
-          <PatientList
-            patients={data?.data || []}
-            isLoading={isLoading}
-            isError={isError}
-            error={error}
-            onViewDetails={handleViewDetails}
-          />
-        </CardContent>
-      </Card>
     </div>
   );
 }


### PR DESCRIPTION
💡 **What:**
- Added a "Limpar filtros" (Clear filters) button to `PatientList` when no patients are found but filters are active.
- Refactored `PatientFilters` to be a controlled component, allowing the parent page to reset its state.
- Updated `PatientsPage` to manage filter state and pass it down to `PatientFilters` and `PatientList`.

🎯 **Why:**
- Users were previously stuck with a generic "No patients found" message even when filters were applied, requiring manual clearing of each filter to see results again.
- This change provides a clear path to recover from an empty state caused by over-filtering.

📸 **Before/After:**
- Before: Generic empty state message.
- After: Context-aware message ("Ajuste os filtros...") and a clear action button.

♿ **Accessibility:**
- The clear button is a standard button component with focus states and keyboard support.
- The empty state message provides clear feedback about the current state.

---
*PR created automatically by Jules for task [2178848507462862703](https://jules.google.com/task/2178848507462862703) started by @mateuscarlos*