### PR TITLE
🎨 Palette: Add 'Clear Filters' action to empty state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,11 @@
 ## 2025-01-26 - Icon-Only Button Accessibility
 **Learning:** Icon-only buttons are invisible to screen readers without labels. Tooltips alone are insufficient for AT users.
 **Action:** Pair `Tooltip` (for sighted users) with `aria-label` (for AT users) on every icon button.
+
+## 2025-02-12 - Controlled Filters for Clear Actions
+**Learning:** Implementing a "Clear All Filters" action requires filter components (like search inputs) to be fully controlled by the parent state. Uncontrolled components with local state will not reflect the reset action.
+**Action:** When designing filter components, prefer controlled props (`value` + `onChange`) over local state to enable external reset actions.
+
+## 2025-02-12 - Modal Placement and Nesting
+**Learning:** Dialog components (using Radix/Shadcn) should not be nested inside inline elements like `<span>` or layout-specific containers like `CardHeader`. This causes layout bugs and invalid HTML structure.
+**Action:** Place `Dialog` components at the end of the page component's JSX return, outside of other structural elements.

--- a/src/modules/patients/presentation/components/PatientFilters.tsx
+++ b/src/modules/patients/presentation/components/PatientFilters.tsx
@@ -25,23 +25,26 @@ interface PatientFiltersProps {
   onSearchChange: (search: string) => void;
   onStatusChange: (status: PatientStatus | 'all') => void;
   onPriorityChange: (priority: PatientPriority | 'all') => void;
+  search?: string;
+  status?: PatientStatus;
+  priority?: PatientPriority;
 }
 
 export function PatientFilters({
   onSearchChange,
   onStatusChange,
   onPriorityChange,
+  search = '',
+  status,
+  priority,
 }: PatientFiltersProps) {
-  const [search, setSearch] = useState('');
   const [showFilters, setShowFilters] = useState(false);
 
   const handleSearchChange = (value: string) => {
-    setSearch(value);
     onSearchChange(value);
   };
 
   const handleClearSearch = () => {
-    setSearch('');
     onSearchChange('');
   };
 
@@ -107,7 +110,10 @@ export function PatientFilters({
         >
           <div>
             <label className="text-sm font-medium mb-2 block">Status</label>
-            <Select onValueChange={(value) => onStatusChange(value as PatientStatus | 'all')}>
+            <Select
+              value={status || 'all'}
+              onValueChange={(value) => onStatusChange(value as PatientStatus | 'all')}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Todos os status" />
               </SelectTrigger>
@@ -123,7 +129,10 @@ export function PatientFilters({
 
           <div>
             <label className="text-sm font-medium mb-2 block">Prioridade</label>
-            <Select onValueChange={(value) => onPriorityChange(value as PatientPriority | 'all')}>
+            <Select
+              value={priority || 'all'}
+              onValueChange={(value) => onPriorityChange(value as PatientPriority | 'all')}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Todas as prioridades" />
               </SelectTrigger>

--- a/src/modules/patients/presentation/components/PatientList.tsx
+++ b/src/modules/patients/presentation/components/PatientList.tsx
@@ -8,6 +8,7 @@ import { Patient } from '../../domain';
 import { Skeleton } from '@/shared/ui/skeleton';
 import { AlertCircle } from 'lucide-react';
 import { Alert, AlertDescription } from '@/shared/ui/alert';
+import { Button } from '@/shared/ui/button';
 
 interface PatientListProps {
   patients: Patient[];
@@ -15,6 +16,8 @@ interface PatientListProps {
   isError: boolean;
   error?: Error | null;
   onViewDetails: (id: string) => void;
+  hasActiveFilters?: boolean;
+  onClearFilters?: () => void;
 }
 
 export function PatientList({ 
@@ -22,7 +25,9 @@ export function PatientList({
   isLoading, 
   isError, 
   error,
-  onViewDetails 
+  onViewDetails,
+  hasActiveFilters,
+  onClearFilters
 }: PatientListProps) {
   // Loading State
   if (isLoading) {
@@ -57,9 +62,16 @@ export function PatientList({
           <AlertCircle className="w-8 h-8 text-muted-foreground" />
         </div>
         <h3 className="text-lg font-semibold mb-2">Nenhum paciente encontrado</h3>
-        <p className="text-muted-foreground">
-          Ajuste os filtros ou cadastre um novo paciente
+        <p className="text-muted-foreground mb-4">
+          {hasActiveFilters
+            ? 'Não encontramos resultados para os filtros selecionados.'
+            : 'Nenhum paciente cadastrado no sistema.'}
         </p>
+        {hasActiveFilters && onClearFilters && (
+          <Button variant="outline" onClick={onClearFilters}>
+            Limpar Filtros
+          </Button>
+        )}
       </div>
     );
   }

--- a/src/modules/patients/presentation/pages/PatientsPage.tsx
+++ b/src/modules/patients/presentation/pages/PatientsPage.tsx
@@ -26,6 +26,15 @@ export function PatientsPage() {
 
   const { data, isLoading, isError, error } = usePatients(filters);
 
+  const hasActiveFilters = !!(filters.search || filters.status || filters.priority);
+
+  const handleClearFilters = () => {
+    setFilters({
+      page: 1,
+      pageSize: 20,
+    });
+  };
+
   const handleSearchChange = (search: string) => {
     setFilters(prev => ({ ...prev, search: search || undefined, page: 1 }));
   };
@@ -98,6 +107,9 @@ export function PatientsPage() {
             onSearchChange={handleSearchChange}
             onStatusChange={handleStatusChange}
             onPriorityChange={handlePriorityChange}
+            search={filters.search}
+            status={filters.status}
+            priority={filters.priority}
           />
         </CardContent>
       </Card>
@@ -109,7 +121,23 @@ export function PatientsPage() {
             <CardTitle>Lista de Pacientes</CardTitle>
             {data?.pagination && (
               <span className="text-sm text-muted-foreground">
-
+                {data.pagination.total} paciente{data.pagination.total !== 1 ? 's' : ''} encontrado{data.pagination.total !== 1 ? 's' : ''}
+              </span>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          <PatientList
+            patients={data?.data || []}
+            isLoading={isLoading}
+            isError={isError}
+            error={error}
+            onViewDetails={handleViewDetails}
+            hasActiveFilters={hasActiveFilters}
+            onClearFilters={handleClearFilters}
+          />
+        </CardContent>
+      </Card>
       {/* Modal do Formulário de Cadastro */}
       <Dialog open={isFormOpen} onOpenChange={setIsFormOpen}>
         <DialogContent className="max-w-5xl max-h-[90vh] p-0">
@@ -129,21 +157,6 @@ export function PatientsPage() {
           </ScrollArea>
         </DialogContent>
       </Dialog>
-                {data.pagination.total} paciente{data.pagination.total !== 1 ? 's' : ''} encontrado{data.pagination.total !== 1 ? 's' : ''}
-              </span>
-            )}
-          </div>
-        </CardHeader>
-        <CardContent>
-          <PatientList
-            patients={data?.data || []}
-            isLoading={isLoading}
-            isError={isError}
-            error={error}
-            onViewDetails={handleViewDetails}
-          />
-        </CardContent>
-      </Card>
     </div>
   );
 }


### PR DESCRIPTION
This PR improves the UX of the Patient List by adding a "Clear Filters" action to the empty state when filters are active.

**Changes:**
- **`PatientList`**: Added an actionable empty state. When no patients are found due to active filters, a "Limpar Filtros" button is shown.
- **`PatientFilters`**: Refactored to be a controlled component. It now accepts `search`, `status`, and `priority` props, enabling the parent component to reset the filter inputs.
- **`PatientsPage`**:
    - Implemented logic to detect active filters (`hasActiveFilters`).
    - Added `handleClearFilters` to reset all filters to their default state.
    - **Bug Fix**: Moved the `<Dialog>` component out of the `<span className="text-sm text-muted-foreground">` element inside the Card Header to fix invalid HTML nesting and potential hydration issues.

**Verification:**
- Verified visually using Playwright that applying a filter shows the empty state button, and clicking it clears the filters and restores the list.
- Verified that the `Dialog` is correctly placed in the DOM.

---
*PR created automatically by Jules for task [2100056492917891953](https://jules.google.com/task/2100056492917891953) started by @mateuscarlos*