### PR TITLE
⚡ Bolt: Debounce patient search input to reduce re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-02-18 - Nested Suspense for Layouts
 **Learning:** Placing a `Suspense` boundary inside the Layout component (wrapping `Outlet`) instead of just at the top level allows the sidebar/header to remain visible while the page content loads.
 **Action:** Identify Layout components and wrap their `Outlet` in `Suspense` to avoid "white screen" flashes during navigation.
+
+## 2025-02-18 - Debounce Pattern for Search Inputs
+**Learning:** When using a `useDebounce` hook in a child component to filter parent data, the parent's callback function (passed as a prop) must be wrapped in `useCallback`. Otherwise, the parent's re-render (triggered by the debounced update) creates a new callback reference, firing the child's `useEffect` again, potentially leading to an infinite loop or redundant updates.
+**Action:** Always wrap state-updating handlers passed to debounced child components in `useCallback`.

--- a/src/modules/patients/presentation/components/PatientFilters.tsx
+++ b/src/modules/patients/presentation/components/PatientFilters.tsx
@@ -3,7 +3,8 @@
  * Barra de filtros e busca de pacientes
  */
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useDebounce } from '@/shared/hooks';
 import { Input } from '@/shared/ui/input';
 import { Button } from '@/shared/ui/button';
 import { Search, Filter, X } from 'lucide-react';
@@ -33,16 +34,19 @@ export function PatientFilters({
   onPriorityChange,
 }: PatientFiltersProps) {
   const [search, setSearch] = useState('');
+  const debouncedSearch = useDebounce(search, 500);
   const [showFilters, setShowFilters] = useState(false);
+
+  useEffect(() => {
+    onSearchChange(debouncedSearch);
+  }, [debouncedSearch, onSearchChange]);
 
   const handleSearchChange = (value: string) => {
     setSearch(value);
-    onSearchChange(value);
   };
 
   const handleClearSearch = () => {
     setSearch('');
-    onSearchChange('');
   };
 
   return (

--- a/src/modules/patients/presentation/pages/PatientsPage.tsx
+++ b/src/modules/patients/presentation/pages/PatientsPage.tsx
@@ -4,7 +4,7 @@
  * Arquitetura modular: separação de domínio, dados e apresentação
  */
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
@@ -26,25 +26,25 @@ export function PatientsPage() {
 
   const { data, isLoading, isError, error } = usePatients(filters);
 
-  const handleSearchChange = (search: string) => {
+  const handleSearchChange = useCallback((search: string) => {
     setFilters(prev => ({ ...prev, search: search || undefined, page: 1 }));
-  };
+  }, []);
 
-  const handleStatusChange = (status: PatientStatus | 'all') => {
+  const handleStatusChange = useCallback((status: PatientStatus | 'all') => {
     setFilters(prev => ({ 
       ...prev, 
       status: status === 'all' ? undefined : status,
       page: 1 
     }));
-  };
+  }, []);
 
-  const handlePriorityChange = (priority: PatientPriority | 'all') => {
+  const handlePriorityChange = useCallback((priority: PatientPriority | 'all') => {
     setFilters(prev => ({ 
       ...prev, 
       priority: priority === 'all' ? undefined : priority,
       page: 1 
     }));
-  };
+  }, []);
 
   const handleViewDetails = (id: string) => {
     // TODO: Navegar para página de detalhes ou abrir modal

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -2,3 +2,4 @@
 export * from './use-toast';
 export * from './use-mobile';
 export * from './useViaCep';
+export * from './use-debounce';

--- a/src/shared/hooks/use-debounce.ts
+++ b/src/shared/hooks/use-debounce.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Hook to debounce a value.
+ *
+ * @param value The value to debounce.
+ * @param delay The delay in milliseconds.
+ * @returns The debounced value.
+ */
+export function useDebounce<T>(value: T, delay: number = 500): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
💡 **What:**
Implemented a `useDebounce` hook and applied it to the patient search filter. Wrapped parent component handlers in `useCallback`.

🎯 **Why:**
Typing in the search input was triggering immediate state updates and potential API calls/re-filtering on every keystroke. This causes performance issues and unnecessary network traffic.

📊 **Impact:**
Reduces the number of filter updates and potential API requests significantly while typing. Updates are now triggered 500ms after the user stops typing.

🔬 **Measurement:**
Verified the debounce logic conceptually with a script `verification/verify_debounce_logic.ts` (passed).
Verified no build errors with `pnpm build`.
Verified logic correctness via code review.

---
*PR created automatically by Jules for task [9399527992076046308](https://jules.google.com/task/9399527992076046308) started by @mateuscarlos*