### PR TITLE
🎨 Palette: Standardize Button Loading State

### DIFF
--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -6,7 +6,7 @@
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
-import { Loader2, Search } from 'lucide-react';
+import { Search } from 'lucide-react';
 
 import { PatientFormData, patientFormSchema } from '../forms/PatientFormSchema';
 import { PatientStatus } from '@/modules/patients/domain/Patient.entity';
@@ -220,13 +220,9 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                     variant="outline"
                     size="icon"
                     onClick={handleFetchAddress}
-                    disabled={loadingCep}
+                    isLoading={loadingCep}
                   >
-                    {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Search className="h-4 w-4" />
-                    )}
+                    <Search className="h-4 w-4" />
                   </Button>
                 </div>
                 {errors.zipCode && (
@@ -567,16 +563,9 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
           <Button
             type="button"
             onClick={handleConfirmSave}
-            disabled={isSubmitting}
+            isLoading={isSubmitting}
           >
-            {isSubmitting ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Salvando...
-              </>
-            ) : (
-              'Salvar'
-            )}
+            {isSubmitting ? 'Salvando...' : 'Salvar'}
           </Button>
         </div>
       </form>

--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import { Loader2 } from "lucide-react";
 
 import { cn } from "@/shared/utils/cn";
 
@@ -37,17 +38,38 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  isLoading?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, asChild = false, isLoading = false, children, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
+
+    const isDisabled = props.disabled || isLoading;
+
+    if (asChild) {
+      return (
+        <Comp
+          className={cn(buttonVariants({ variant, size, className }))}
+          ref={ref}
+          disabled={isDisabled}
+          {...props}
+        >
+          {children}
+        </Comp>
+      );
+    }
+
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
+        disabled={isDisabled}
         {...props}
-      />
+      >
+        {isLoading && <Loader2 className={cn("h-4 w-4 animate-spin", size === "icon" ? "" : "mr-2")} />}
+        {!(isLoading && size === "icon") && children}
+      </Comp>
     );
   },
 );


### PR DESCRIPTION
💡 **What:** Added a reusable `isLoading` prop to the `Button` component and updated `PatientForm` to use it.
🎯 **Why:** To eliminate repetitive manual loading state implementations and ensure consistent spinner size, placement, and button disabling across the application.
📸 **Before/After:** No visual change in `PatientForm` behavior (that's good!), but the underlying code is cleaner. The loading spinner is now automatically handled by the button.
♿ **Accessibility:** The button is automatically disabled when loading, preventing multiple submissions. Ideally, we should also add `aria-busy="true"`, but `disabled` covers interaction blocking.

---
*PR created automatically by Jules for task [841251075560243129](https://jules.google.com/task/841251075560243129) started by @mateuscarlos*