### PR TITLE
🛡️ Sentinel: [HIGH] Prevent CSS injection in ChartStyle

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `.env` file containing environment variables (potentially secrets) was tracked in the git repository.
 **Learning:** Initial project setup or template generation failed to include `.env` in `.gitignore`, leading to accidental tracking of local configuration.
 **Prevention:** Always verify `.gitignore` includes sensitive file patterns (`.env`, `*.pem`, etc.) before the first commit. Use pre-commit hooks to scan for secrets.
+
+## 2026-02-05 - CSS Injection in ChartStyle
+**Vulnerability:** The `ChartStyle` component used `dangerouslySetInnerHTML` to inject styles with unsanitized user inputs (`id`, `key`, `color`).
+**Learning:** CSS injection is often overlooked but can allow attackers to inject arbitrary CSS, potentially leading to phishing or XSS via attributes.
+**Prevention:** Always sanitize inputs when constructing CSS strings, especially within `<style>` blocks. Use whitelisting for IDs/keys and strict blacklisting for values.

--- a/src/shared/ui/chart.test.ts
+++ b/src/shared/ui/chart.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeForStyle } from './chart.utils';
+
+describe('sanitizeForStyle', () => {
+  it('should sanitize IDs by removing non-alphanumeric characters', () => {
+    expect(sanitizeForStyle('valid-id', 'id')).toBe('valid-id');
+    expect(sanitizeForStyle('valid_id_123', 'id')).toBe('valid_id_123');
+    expect(sanitizeForStyle('invalid id', 'id')).toBe('invalidid');
+    expect(sanitizeForStyle('invalid/id', 'id')).toBe('invalidid');
+    expect(sanitizeForStyle('invalid<id>', 'id')).toBe('invalidid');
+    expect(sanitizeForStyle('foo] { body { display: none; } } [data-chart=bar', 'id'))
+      .toBe('foobodydisplaynonedata-chartbar');
+  });
+
+  it('should sanitize keys by removing non-alphanumeric characters', () => {
+    expect(sanitizeForStyle('valid-key', 'key')).toBe('valid-key');
+    expect(sanitizeForStyle('color', 'key')).toBe('color');
+    // Dashes and underscores are allowed by /[^a-zA-Z0-9_-]/g
+    expect(sanitizeForStyle('--custom-prop', 'key')).toBe('--custom-prop');
+
+    expect(sanitizeForStyle('foo: bar', 'key')).toBe('foobar');
+    expect(sanitizeForStyle('foo; background: red', 'key')).toBe('foobackgroundred');
+  });
+
+  it('should sanitize values by removing dangerous characters', () => {
+    // Allowed
+    expect(sanitizeForStyle('red', 'value')).toBe('red');
+    expect(sanitizeForStyle('#ff0000', 'value')).toBe('#ff0000');
+    expect(sanitizeForStyle('rgba(0, 0, 0, 0.5)', 'value')).toBe('rgba(0, 0, 0, 0.5)');
+    expect(sanitizeForStyle('var(--color-primary)', 'value')).toBe('var(--color-primary)');
+
+    // Dangerous
+    expect(sanitizeForStyle('red; background: blue', 'value')).toBe('red background: blue');
+    expect(sanitizeForStyle('red } body { display: none', 'value')).toBe('red  body  display: none');
+    expect(sanitizeForStyle('"><script>alert(1)</script>', 'value')).toBe('scriptalert(1)/script');
+  });
+
+  it('should handle empty input', () => {
+      expect(sanitizeForStyle('', 'id')).toBe('');
+      expect(sanitizeForStyle(null as unknown as string, 'id')).toBe('');
+      expect(sanitizeForStyle(undefined as unknown as string, 'id')).toBe('');
+  });
+});

--- a/src/shared/ui/chart.tsx
+++ b/src/shared/ui/chart.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as RechartsPrimitive from "recharts";
 
 import { cn } from "@/shared/utils/cn";
+import { sanitizeForStyle } from "@/shared/ui/chart.utils";
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const;
@@ -80,13 +81,18 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
         __html: Object.entries(THEMES)
           .map(
             ([theme, prefix]) => `
-${prefix} [data-chart=${id}] {
+${prefix} [data-chart=${sanitizeForStyle(id, "id")}] {
 ${colorConfig
   .map(([key, itemConfig]) => {
     const color =
       itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
       itemConfig.color;
-    return color ? `  --color-${key}: ${color};` : null;
+    return color
+      ? `  --color-${sanitizeForStyle(key, "key")}: ${sanitizeForStyle(
+          color,
+          "value",
+        )};`
+      : null;
   })
   .join("\n")}
 }

--- a/src/shared/ui/chart.utils.ts
+++ b/src/shared/ui/chart.utils.ts
@@ -1,0 +1,24 @@
+/**
+ * Sanitizes input for use in CSS styles to prevent injection attacks.
+ *
+ * @param value The string to sanitize
+ * @param type The context of usage ('id', 'key', or 'value')
+ * @returns The sanitized string
+ */
+export function sanitizeForStyle(
+  value: string,
+  type: "id" | "key" | "value",
+): string {
+  if (!value) {
+    return "";
+  }
+
+  // For IDs and property keys, we want strict alphanumeric + dash/underscore
+  if (type === "id" || type === "key") {
+    return value.replace(/[^a-zA-Z0-9_-]/g, "");
+  }
+
+  // For values (colors), we need to allow valid CSS characters but block dangerous ones
+  // We strip: ; (property separator), { } (block delimiters), < > (HTML tags), " ' (quotes)
+  return value.replace(/[;{}<>"']/g, "");
+}


### PR DESCRIPTION
This PR addresses a CSS Injection vulnerability in the `ChartStyle` component.

The component previously used `dangerouslySetInnerHTML` to inject styles using unsanitized `id`, `key`, and `color` props. This could allow attackers to inject arbitrary CSS rules or potentially execute XSS if they could manipulate these inputs.

**Fix:**
- Introduced `sanitizeForStyle` utility function.
- Sanitizes `id` and `key` by allowing only alphanumeric characters, dashes, and underscores.
- Sanitizes `value` (color) by stripping characters that could break out of the style attribute or tag (`;`, `{`, `}`, `<`, `>`, `"`, `'`).

**Verification:**
- Added unit tests covering various injection attempts.
- Verified build and lint checks pass (for modified files).

---
*PR created automatically by Jules for task [3802378548388895969](https://jules.google.com/task/3802378548388895969) started by @mateuscarlos*