### PR TITLE
feat(ui): add isLoading prop to Button component

### DIFF
--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import { Loader2 } from "lucide-react";
 
 import { cn } from "@/shared/utils/cn";
 
@@ -37,17 +38,52 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  isLoading?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  (
+    {
+      className,
+      variant,
+      size,
+      asChild = false,
+      isLoading = false,
+      children,
+      disabled,
+      ...props
+    },
+    ref,
+  ) => {
     const Comp = asChild ? Slot : "button";
+
+    if (asChild) {
+      return (
+        <Comp
+          className={cn(buttonVariants({ variant, size, className }))}
+          ref={ref}
+          disabled={disabled}
+          {...props}
+        >
+          {children}
+        </Comp>
+      );
+    }
+
     return (
-      <Comp
+      <button
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
+        disabled={isLoading || disabled}
         {...props}
-      />
+      >
+        {isLoading && (
+          <Loader2
+            className={cn("h-4 w-4 animate-spin", size !== "icon" && "mr-2")}
+          />
+        )}
+        {!(isLoading && size === "icon") && children}
+      </button>
     );
   },
 );


### PR DESCRIPTION
Added a standardized `isLoading` prop to the shared `Button` component to improve UX and developer experience.

## What
- Added `isLoading?: boolean` to `ButtonProps`.
- Implemented visual loading state using `Loader2` from `lucide-react`.
- When `isLoading` is true:
  - The button is disabled.
  - A spinner is shown.
  - For icon buttons (`size="icon"`), the icon is replaced by the spinner.
  - For standard buttons, the spinner is prepended to the text.
- Fixed a potential regression where `disabled` was not passed to `asChild` components.

## Why
- Developers were manually implementing loading states (spinner + disabled) in multiple places.
- This provides a consistent, accessible, and easy-to-use pattern for async actions.

## Accessibility
- The button is programmatically disabled when loading.
- `aria-label` and other accessibility attributes are preserved.


---
*PR created automatically by Jules for task [549627405058333663](https://jules.google.com/task/549627405058333663) started by @mateuscarlos*