### PR TITLE
🎨 Palette: Add Tooltips and ARIA Labels to Icon-Only Buttons

### DIFF
--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -14,6 +14,7 @@ import { useViaCep } from '@/shared/hooks/useViaCep';
 import { maskCPF, maskCEP, maskPhone, unmaskCPF, unmaskCEP, unmaskPhone } from '@/shared/utils/inputMasks';
 import { ConfirmationDialog } from '@/shared/ui/confirmation-dialog';
 import { Button } from '@/shared/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
 import { Input } from '@/shared/ui/input';
 import { Label } from '@/shared/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select';
@@ -215,19 +216,27 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                       setValue('zipCode', unmaskCEP(masked));
                     }}
                   />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    onClick={handleFetchAddress}
-                    disabled={loadingCep}
-                  >
-                    {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Search className="h-4 w-4" />
-                    )}
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={handleFetchAddress}
+                        disabled={loadingCep}
+                        aria-label="Buscar endereço por CEP"
+                      >
+                        {loadingCep ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Search className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Buscar endereço por CEP</p>
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 {errors.zipCode && (
                   <p className="text-sm text-destructive">{errors.zipCode.message}</p>

--- a/src/pages/Patients.tsx
+++ b/src/pages/Patients.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
 import { Plus, Search, Filter } from "lucide-react";
 import { Input } from "@/shared/ui/input";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from "@/shared/ui/sheet";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { ScrollArea } from "@/shared/ui/scroll-area";
 import { PatientForm } from "@/modules/patients/presentation/components/PatientForm";
 import { PatientFormData } from "@/modules/patients/presentation/forms/PatientFormSchema";
@@ -80,9 +81,16 @@ const Patients = () => {
                   className="pl-9 w-[200px] lg:w-[300px]"
                 />
               </div>
-              <Button variant="outline" size="icon">
-                <Filter className="h-4 w-4" />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" aria-label="Filtrar pacientes">
+                    <Filter className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Filtrar pacientes</p>
+                </TooltipContent>
+              </Tooltip>
             </div>
           </div>
         </CardHeader>


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes and wrapped icon-only buttons in `<Tooltip>` components. Specifically, updated the "Search" button for CEP lookup in `PatientForm.tsx` and the "Filter" button in the `Patients.tsx` page.

🎯 **Why:** Icon-only buttons without accessible labels are invisible to screen readers, and without tooltips, sighted users may not understand what the icon represents. This small UX enhancement improves both accessibility for assistive technologies and usability for sighted users.

♿ **Accessibility:** Added `aria-label` to provide context for screen readers and `Tooltip` components for visual hover/focus indicators.

---
*PR created automatically by Jules for task [14657941046913815200](https://jules.google.com/task/14657941046913815200) started by @mateuscarlos*