### PR TITLE
🎨 Palette: Icon-only button accessibility & search input polish

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -17,6 +17,7 @@ import {
   Building
 } from "lucide-react";
 import { Button } from "@/shared/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/shared/ui/tooltip";
 import { Sheet, SheetContent, SheetTrigger } from "@/shared/ui/sheet";
 import { cn } from "@/shared/utils/cn";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/shared/ui/collapsible";
@@ -153,11 +154,20 @@ const AppLayout = () => {
           </div>
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
-            <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
-              </Button>
-            </SheetTrigger>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <SheetTrigger asChild>
+                    <Button variant="ghost" size="icon" aria-label="Menu principal">
+                      <Menu className="h-6 w-6" />
+                    </Button>
+                  </SheetTrigger>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Menu principal</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
             <SheetContent side="left" className="p-0 w-64">
               <Sidebar onClose={() => setIsMobileOpen(false)} />
             </SheetContent>

--- a/src/pages/Patients.tsx
+++ b/src/pages/Patients.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/shared/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
 import { Plus, Search, Filter } from "lucide-react";
 import { Input } from "@/shared/ui/input";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from "@/shared/ui/sheet";
 import { ScrollArea } from "@/shared/ui/scroll-area";
 import { PatientForm } from "@/modules/patients/presentation/components/PatientForm";
@@ -80,9 +81,16 @@ const Patients = () => {
                   className="pl-9 w-[200px] lg:w-[300px]"
                 />
               </div>
-              <Button variant="outline" size="icon">
-                <Filter className="h-4 w-4" />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" aria-label="Filtrar pacientes">
+                    <Filter className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Filtrar pacientes</p>
+                </TooltipContent>
+              </Tooltip>
             </div>
           </div>
         </CardHeader>

--- a/src/shared/ui/input.tsx
+++ b/src/shared/ui/input.tsx
@@ -9,6 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
         type={type}
         className={cn(
           "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          type === "search" && "[&::-webkit-search-cancel-button]:hidden",
           className,
         )}
         ref={ref}


### PR DESCRIPTION
- Adds `aria-label` to icon-only buttons (`Menu principal` and `Filtrar pacientes`) to ensure screen-reader accessibility.
- Wraps icon-only buttons in Radix Tooltips (`TooltipProvider`, `Tooltip`, `TooltipTrigger`, `TooltipContent`) to provide visual context to sighted users.
- Hides the native webkit search cancel button (`[&::-webkit-search-cancel-button]:hidden`) on the global Shadcn Input component whenever `type="search"`, preventing visual conflict with custom clear behaviors.

---
*PR created automatically by Jules for task [11611667079207520789](https://jules.google.com/task/11611667079207520789) started by @mateuscarlos*