### PR TITLE
🛡️ Sentinel: [HIGH] Sanitize Chart Style Configurations

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `.env` file containing environment variables (potentially secrets) was tracked in the git repository.
 **Learning:** Initial project setup or template generation failed to include `.env` in `.gitignore`, leading to accidental tracking of local configuration.
 **Prevention:** Always verify `.gitignore` includes sensitive file patterns (`.env`, `*.pem`, etc.) before the first commit. Use pre-commit hooks to scan for secrets.
+
+## 2026-02-01 - XSS via unescaped variables in dangerouslySetInnerHTML
+**Vulnerability:** The application was using `dangerouslySetInnerHTML` in `ChartStyle` (`src/shared/ui/chart.tsx`) with unsanitized `id`, `key`, and `color` configuration values.
+**Learning:** This exposes the application to XSS and arbitrary CSS injection if an attacker can control the chart configuration properties. CSS parsing can be broken by injecting specific control characters like `<`, `>`, and `;`.
+**Prevention:** Avoid injecting dynamic CSS configurations by using inline styles directly on elements or proper CSS-in-JS libraries. If `dangerouslySetInnerHTML` must be used for dynamic stylesheets, always rigorously sanitize input by stripping characters needed to break out of the context (e.g. `[<>;}\[\]"']`).

--- a/src/shared/ui/chart.tsx
+++ b/src/shared/ui/chart.tsx
@@ -65,6 +65,12 @@ const ChartContainer = React.forwardRef<
 });
 ChartContainer.displayName = "Chart";
 
+const sanitizeForStyle = (str: string) => {
+  if (typeof str !== "string") return str;
+  // eslint-disable-next-line no-useless-escape
+  return str.replace(/[<>;}\[\]"']/g, "");
+};
+
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
   const colorConfig = Object.entries(config).filter(
     ([_, config]) => config.theme || config.color,
@@ -74,19 +80,23 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
     return null;
   }
 
+  const sanitizedId = sanitizeForStyle(id);
+
   return (
     <style
       dangerouslySetInnerHTML={{
         __html: Object.entries(THEMES)
           .map(
             ([theme, prefix]) => `
-${prefix} [data-chart=${id}] {
+${prefix} [data-chart=${sanitizedId}] {
 ${colorConfig
   .map(([key, itemConfig]) => {
     const color =
       itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
       itemConfig.color;
-    return color ? `  --color-${key}: ${color};` : null;
+    const sanitizedKey = sanitizeForStyle(key);
+    const sanitizedColor = color ? sanitizeForStyle(color) : color;
+    return sanitizedColor ? `  --color-${sanitizedKey}: ${sanitizedColor};` : null;
   })
   .join("\n")}
 }


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: Potential XSS via unescaped variables in `dangerouslySetInnerHTML` CSS injection. The `id`, `key` and `color` configuration from `ChartConfig` were vulnerable.
* 🎯 Impact: Arbitrary CSS injection or XSS could be triggered.
* 🔧 Fix: Implemented `sanitizeForStyle` helper to block the `[<>;}\[\]"']` characters and applied it to variables before template interpolation.
* ✅ Verification: Tested using custom Node script ensuring characters get sanitized properly. Also verified the existing testsuite and lint via `pnpm lint`.

---
*PR created automatically by Jules for task [2982654484984587856](https://jules.google.com/task/2982654484984587856) started by @mateuscarlos*