### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSS injection vulnerability in ChartStyle

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `.env` file containing environment variables (potentially secrets) was tracked in the git repository.
 **Learning:** Initial project setup or template generation failed to include `.env` in `.gitignore`, leading to accidental tracking of local configuration.
 **Prevention:** Always verify `.gitignore` includes sensitive file patterns (`.env`, `*.pem`, etc.) before the first commit. Use pre-commit hooks to scan for secrets.
+
+## 2026-02-01 - CSS Injection in ChartStyle
+**Vulnerability:** The `ChartStyle` component in `src/shared/ui/chart.tsx` used `dangerouslySetInnerHTML` to inject dynamic styles based on a configuration object without sanitizing keys or colors.
+**Learning:** Relying on unsanitized input to construct CSS rules inside a <style> block allows attackers to inject arbitrary CSS, potentially breaking the layout or leading to XSS vulnerabilities if the input is user-controlled.
+**Prevention:** Always sanitize input dynamically injected into CSS rules. In this case, a `sanitizeForStyle` helper was introduced to strip dangerous characters (`<`, `>`, `;`, `}`, `[`, `]`, `"`, `'`) from keys and colors before interpolation.

--- a/src/shared/ui/chart.tsx
+++ b/src/shared/ui/chart.tsx
@@ -65,6 +65,11 @@ const ChartContainer = React.forwardRef<
 });
 ChartContainer.displayName = "Chart";
 
+const sanitizeForStyle = (value: string) => {
+  if (typeof value !== "string") return value;
+  return value.replace(/[<>;}\[\]"']/g, ""); // eslint-disable-line no-useless-escape
+};
+
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
   const colorConfig = Object.entries(config).filter(
     ([_, config]) => config.theme || config.color,
@@ -86,7 +91,7 @@ ${colorConfig
     const color =
       itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
       itemConfig.color;
-    return color ? `  --color-${key}: ${color};` : null;
+    return color ? `  --color-${sanitizeForStyle(key)}: ${sanitizeForStyle(color)};` : null;
   })
   .join("\n")}
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: CSS Injection/XSS in `ChartStyle` due to dynamically injecting properties into a `<style>` tag using `dangerouslySetInnerHTML` with unsanitized keys/colors.
🎯 Impact: Attackers could inject arbitrary CSS that breaks the layout or potentially leads to XSS vulnerabilities if the input reaches these configurations.
🔧 Fix: Created a `sanitizeForStyle` helper in `src/shared/ui/chart.tsx` that strictly strips dangerous characters (`<`, `>`, `;`, `}`, `[`, `]`, `"`, `'`) prior to interpolation inside the `<style>` block.
✅ Verification: Ran `pnpm lint`, `pnpm build`, and passed code review.

---
*PR created automatically by Jules for task [204945059174623721](https://jules.google.com/task/204945059174623721) started by @mateuscarlos*