### PR TITLE
🎨 Palette: Improve Accessibility for Icon-only Buttons

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,7 +154,7 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
+              <Button variant="ghost" size="icon" aria-label="Abrir menu">
                 <Menu className="h-6 w-6" />
               </Button>
             </SheetTrigger>

--- a/src/pages/Patients.tsx
+++ b/src/pages/Patients.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
 import { Plus, Search, Filter } from "lucide-react";
 import { Input } from "@/shared/ui/input";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from "@/shared/ui/sheet";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/shared/ui/tooltip";
 import { ScrollArea } from "@/shared/ui/scroll-area";
 import { PatientForm } from "@/modules/patients/presentation/components/PatientForm";
 import { PatientFormData } from "@/modules/patients/presentation/forms/PatientFormSchema";
@@ -73,16 +74,26 @@ const Patients = () => {
             <CardTitle>Lista de Pacientes</CardTitle>
             <div className="flex gap-2">
               <div className="relative w-full max-w-sm">
-                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-gray-500" />
+                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-gray-500" aria-hidden="true" />
                 <Input
                   type="search"
                   placeholder="Buscar paciente..."
                   className="pl-9 w-[200px] lg:w-[300px]"
+                  aria-label="Buscar paciente"
                 />
               </div>
-              <Button variant="outline" size="icon">
-                <Filter className="h-4 w-4" />
-              </Button>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button variant="outline" size="icon" aria-label="Filtrar pacientes">
+                      <Filter className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Filtrar pacientes</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </div>
           </div>
         </CardHeader>

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -39,7 +39,7 @@ const UsersPage = () => {
                   <Shield className="h-4 w-4" />
                   {user.type}
                 </div>
-                <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+                <Button variant="ghost" size="sm" className="h-8 w-8 p-0" aria-label="Configurar usuário">
                   <UserCog className="h-4 w-4" />
                 </Button>
               </div>


### PR DESCRIPTION
💡 What: The UX enhancement added:
Added explicit `aria-label` attributes to various icon-only buttons (`Menu`, `Filter`, `UserCog`) and `aria-hidden` attributes to purely decorative icons (like the `Search` icon). Wrapped the `Filter` icon-only button in a `Tooltip` to explain its functionality to sighted users.

🎯 Why: The user problem it solves:
Screen readers read icon-only buttons merely as "button" if there is no context text, leaving visually-impaired users confused. Tooltips give contextual hints to non-screen-reader users without cluttering the UI.

📸 Before/After: See `patients_tooltip.png` from Playwright verification.

♿ Accessibility:
- Added `aria-label="Abrir menu"` to AppLayout mobile toggle.
- Added `aria-label="Buscar paciente"` and `aria-label="Filtrar pacientes"` to Patients page search bar and filter button.
- Added `aria-hidden="true"` to decorative `Search` icon.
- Added `aria-label="Configurar usuário"` to Users page settings button.
- Implemented `Tooltip` on the `Filter` button.

---
*PR created automatically by Jules for task [12715977914841127214](https://jules.google.com/task/12715977914841127214) started by @mateuscarlos*