### PR TITLE
🎨 Palette: Add accessible label to mobile menu button

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,7 +154,7 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
+              <Button variant="ghost" size="icon" aria-label="Abrir menu principal">
                 <Menu className="h-6 w-6" />
               </Button>
             </SheetTrigger>


### PR DESCRIPTION
💡 What: Added an `aria-label="Abrir menu principal"` to the mobile layout's hamburger menu button.
🎯 Why: The icon-only menu button was completely invisible to screen readers without an accessible name. This makes the primary navigation toggle accessible to AT users.
♿ Accessibility: Ensures the mobile navigation trigger has an accessible name, satisfying WCAG 4.1.2 Name, Role, Value.

---
*PR created automatically by Jules for task [17983678155185059131](https://jules.google.com/task/17983678155185059131) started by @mateuscarlos*