### PR TITLE
⚡ Bolt: Debounce patient search to reduce API calls

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2025-02-18 - Nested Suspense for Layouts
 **Learning:** Placing a `Suspense` boundary inside the Layout component (wrapping `Outlet`) instead of just at the top level allows the sidebar/header to remain visible while the page content loads.
 **Action:** Identify Layout components and wrap their `Outlet` in `Suspense` to avoid "white screen" flashes during navigation.
+## 2025-02-18 - Search Input Debouncing & useCallback
+**Learning:** When debouncing a search input using `useEffect` in a child component, the parent's handler function passed as a prop must be memoized using `useCallback`. Failure to do so causes the parent's function reference to change on every render, which in turn triggers the child's `useEffect` (since the function is in its dependency array), leading to continuous unwanted state updates or infinite render loops.
+**Action:** Always wrap handler functions passed as props to debounced child components with `useCallback` in the parent. Ensure the child's `useEffect` dependencies include both the local value and the stable parent handler.

--- a/src/modules/patients/presentation/components/PatientFilters.tsx
+++ b/src/modules/patients/presentation/components/PatientFilters.tsx
@@ -3,7 +3,7 @@
  * Barra de filtros e busca de pacientes
  */
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Input } from '@/shared/ui/input';
 import { Button } from '@/shared/ui/button';
 import { Search, Filter, X } from 'lucide-react';
@@ -35,11 +35,22 @@ export function PatientFilters({
   const [search, setSearch] = useState('');
   const [showFilters, setShowFilters] = useState(false);
 
+  // ⚡ Bolt: Debounce search input to prevent excessive API calls
+  // Reduces the number of requests while the user is actively typing.
+  // We use a 500ms delay before triggering the parent's onSearchChange.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onSearchChange(search);
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [search, onSearchChange]);
+
   const handleSearchChange = (value: string) => {
     setSearch(value);
-    onSearchChange(value);
   };
 
+  // ⚡ Bolt: Clear search should bypass the debounce and trigger immediately
   const handleClearSearch = () => {
     setSearch('');
     onSearchChange('');

--- a/src/modules/patients/presentation/pages/PatientsPage.tsx
+++ b/src/modules/patients/presentation/pages/PatientsPage.tsx
@@ -4,7 +4,7 @@
  * Arquitetura modular: separação de domínio, dados e apresentação
  */
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
@@ -26,25 +26,31 @@ export function PatientsPage() {
 
   const { data, isLoading, isError, error } = usePatients(filters);
 
-  const handleSearchChange = (search: string) => {
+  // ⚡ Bolt: Memoize filter handlers to prevent unnecessary re-renders
+  // These functions are passed down to PatientFilters. By memoizing them
+  // with useCallback, we ensure their references remain stable across
+  // PatientsPage re-renders. This is crucial because PatientFilters now
+  // uses onSearchChange in its useEffect dependency array for debouncing,
+  // and an unstable reference would cause infinite render loops.
+  const handleSearchChange = useCallback((search: string) => {
     setFilters(prev => ({ ...prev, search: search || undefined, page: 1 }));
-  };
+  }, []);
 
-  const handleStatusChange = (status: PatientStatus | 'all') => {
+  const handleStatusChange = useCallback((status: PatientStatus | 'all') => {
     setFilters(prev => ({ 
       ...prev, 
       status: status === 'all' ? undefined : status,
       page: 1 
     }));
-  };
+  }, []);
 
-  const handlePriorityChange = (priority: PatientPriority | 'all') => {
+  const handlePriorityChange = useCallback((priority: PatientPriority | 'all') => {
     setFilters(prev => ({ 
       ...prev, 
       priority: priority === 'all' ? undefined : priority,
       page: 1 
     }));
-  };
+  }, []);
 
   const handleViewDetails = (id: string) => {
     // TODO: Navegar para página de detalhes ou abrir modal


### PR DESCRIPTION
💡 What: Implemented a 500ms debounce on the patient search input and memoized the filter handlers in the parent page component.
🎯 Why: Typing in the search bar previously triggered immediate state updates and API calls (via `usePatients`) on every keystroke. This causes excessive network requests and unnecessary React re-renders while the user is actively typing.
📊 Impact: Reduces the number of data refetches while typing. A 5-letter search term now triggers 1 request instead of 5, a ~80% reduction in network activity for that action.
🔬 Measurement: Verified using a Playwright script that simulates typing "joao" with 100ms pauses between keystrokes. Observed only a single network request/render update 500ms after the last keystroke, rather than 4 immediate ones.

Also, documented the critical learning regarding `useCallback` and `useEffect` dependencies in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [14752920030647820610](https://jules.google.com/task/14752920030647820610) started by @mateuscarlos*