### PR TITLE
🎨 Palette: Enhance accessibility and clarity of icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2025-01-26 - Icon-Only Button Accessibility
 **Learning:** Icon-only buttons are invisible to screen readers without labels. Tooltips alone are insufficient for AT users.
 **Action:** Pair `Tooltip` (for sighted users) with `aria-label` (for AT users) on every icon button.
+## 2024-03-06 - Tooltips and Dialog Triggers Composition
+**Learning:** When using Radix UI (shadcn-ui) components, placing a `<Tooltip>` directly inside `<SheetTrigger asChild>` (or similar Dialog triggers) breaks the trigger functionality because `<Tooltip>` is a context provider and drops DOM event listeners.
+**Action:** Always compose multiple interactive components by wrapping the context providers around the triggers and nesting the triggers using `asChild`. For example: `<Tooltip><SheetTrigger asChild><TooltipTrigger asChild><Button>...</Button></TooltipTrigger></SheetTrigger></Tooltip>`.

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/shared/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/shared/ui/sheet";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { cn } from "@/shared/utils/cn";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/shared/ui/collapsible";
 
@@ -153,11 +154,18 @@ const AppLayout = () => {
           </div>
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
-            <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
-              </Button>
-            </SheetTrigger>
+            <Tooltip>
+              <SheetTrigger asChild>
+                <TooltipTrigger asChild>
+                  <Button variant="ghost" size="icon" aria-label="Abrir menu de navegação">
+                    <Menu className="h-6 w-6" aria-hidden="true" />
+                  </Button>
+                </TooltipTrigger>
+              </SheetTrigger>
+              <TooltipContent>
+                <p>Menu de navegação</p>
+              </TooltipContent>
+            </Tooltip>
             <SheetContent side="left" className="p-0 w-64">
               <Sidebar onClose={() => setIsMobileOpen(false)} />
             </SheetContent>

--- a/src/pages/Patients.tsx
+++ b/src/pages/Patients.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/shared/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
 import { Plus, Search, Filter } from "lucide-react";
 import { Input } from "@/shared/ui/input";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from "@/shared/ui/sheet";
 import { ScrollArea } from "@/shared/ui/scroll-area";
 import { PatientForm } from "@/modules/patients/presentation/components/PatientForm";
@@ -80,9 +81,16 @@ const Patients = () => {
                   className="pl-9 w-[200px] lg:w-[300px]"
                 />
               </div>
-              <Button variant="outline" size="icon">
-                <Filter className="h-4 w-4" />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" aria-label="Filtros avançados">
+                    <Filter className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Filtros avançados</p>
+                </TooltipContent>
+              </Tooltip>
             </div>
           </div>
         </CardHeader>


### PR DESCRIPTION
💡 **What:** Added `Tooltip` wrappers, explicit `aria-label`s, and `aria-hidden="true"` to the SVG icons for the mobile navigation menu button (`AppLayout.tsx`) and the patients filter button (`Patients.tsx`).
🎯 **Why:** Icon-only buttons are invisible or confusing to users relying on assistive technologies if they lack accessible names. Furthermore, sighted users without context may not immediately recognize the function of an icon. Tooltips solve the sighted-user problem, and ARIA labels solve the screen-reader problem.
📸 **Before/After:** See the attached screenshots in the PR for the visual enhancements.
♿ **Accessibility:** Sighted users gain context via tooltips. Screen readers will now announce "Abrir menu de navegação" and "Filtros avançados" instead of ignoring the buttons or reading generic SVG metadata.

---
*PR created automatically by Jules for task [799748111228803167](https://jules.google.com/task/799748111228803167) started by @mateuscarlos*