### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Unsanitized API Logs Exposing Credentials

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `.env` file containing environment variables (potentially secrets) was tracked in the git repository.
 **Learning:** Initial project setup or template generation failed to include `.env` in `.gitignore`, leading to accidental tracking of local configuration.
 **Prevention:** Always verify `.gitignore` includes sensitive file patterns (`.env`, `*.pem`, etc.) before the first commit. Use pre-commit hooks to scan for secrets.
+
+## 2025-02-27 - Unsanitized API Logs Exposing Credentials
+**Vulnerability:** Axios interceptors logged full request/response bodies, potentially exposing passwords, auth tokens, and PII to the browser console and log aggregators.
+**Learning:** Default API client setups often favor debugging over security. A global object sanitization function must correctly handle recursive data structures and edge cases (like Dates and Blobs).
+**Prevention:** Always implement an interceptor-level data sanitizer (`sanitizeData`) to explicitly mask fields matching sensitive patterns before passing them to console.log or tracking services.

--- a/src/core/config/api.config.ts
+++ b/src/core/config/api.config.ts
@@ -5,6 +5,7 @@
 
 import axios, { AxiosError, AxiosInstance, InternalAxiosRequestConfig, AxiosResponse } from 'axios';
 import { ENV } from './env.config';
+import { sanitizeData } from '@/core/lib/security';
 
 // Criar instância do Axios
 export const apiClient: AxiosInstance = axios.create({
@@ -32,7 +33,7 @@ apiClient.interceptors.request.use(
       console.log('🚀 API Request:', {
         method: config.method?.toUpperCase(),
         url: config.url,
-        data: config.data,
+        data: sanitizeData(config.data),
       });
     }
 
@@ -55,7 +56,7 @@ apiClient.interceptors.response.use(
       console.log('✅ API Response:', {
         status: response.status,
         url: response.config.url,
-        data: response.data,
+        data: sanitizeData(response.data),
       });
     }
 

--- a/src/core/lib/security.ts
+++ b/src/core/lib/security.ts
@@ -1,0 +1,79 @@
+/**
+ * Security Utilities
+ * Tools for data sanitization, masking, and security-related operations.
+ */
+
+// Keys that commonly contain sensitive information
+const SENSITIVE_KEYS = [
+  'password',
+  'token',
+  'secret',
+  'credential',
+  'key',
+  'auth',
+  'session',
+  'cookie',
+  'cpf',
+  'rg',
+  'document',
+  'ssn',
+  'credit',
+  'card',
+  'cvv',
+  'pin',
+  'email',
+  'phone',
+  'address',
+  'zip',
+  'birth',
+];
+
+/**
+ * Recursively sanitizes data by masking sensitive fields.
+ * Useful for logging and debugging without exposing PII or credentials.
+ *
+ * @param data Data to sanitize
+ * @param mask String to replace sensitive values with
+ * @param seen Set to track circular references
+ * @returns Sanitized clone of the data
+ */
+export function sanitizeData<T>(data: T, mask: string = '*** MASKED ***', seen = new WeakSet()): T {
+  // Handle primitive values and null/undefined
+  if (data === null || data === undefined || typeof data !== 'object') {
+    return data;
+  }
+
+  // Handle Dates, Blobs, Files, and other native objects that shouldn't be traversed
+  if (data instanceof Date || data instanceof Blob || data instanceof File) {
+    return data;
+  }
+
+  // Circular reference check
+  if (seen.has(data as object)) {
+    return '[Circular]' as unknown as T;
+  }
+  seen.add(data as object);
+
+  // Handle Arrays
+  if (Array.isArray(data)) {
+    return data.map(item => sanitizeData(item, mask, seen)) as unknown as T;
+  }
+
+  // Handle Objects
+  const sanitized = { ...data } as Record<string, unknown>;
+
+  for (const [key, value] of Object.entries(sanitized)) {
+    // Check if the key matches any sensitive term (case-insensitive partial match)
+    const lowerKey = key.toLowerCase();
+    const isSensitive = SENSITIVE_KEYS.some(sensitiveTerm => lowerKey.includes(sensitiveTerm));
+
+    if (isSensitive) {
+      sanitized[key] = mask;
+    } else {
+      // Recursively sanitize nested objects/arrays
+      sanitized[key] = sanitizeData(value, mask, seen);
+    }
+  }
+
+  return sanitized as T;
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: API Client configuration was directly logging full request and response bodies. If users authenticate or manage sensitive data (e.g. patients PII), passwords, tokens, and documents could be exposed in the browser console.
🎯 Impact: An attacker with physical access or a malicious browser extension could harvest active session tokens, passwords, and user details directly from the console output.
🔧 Fix: Implemented a robust, recursive `sanitizeData` utility in `src/core/lib/security.ts`. Modified `src/core/config/api.config.ts` to wrap both `config.data` and `response.data` using `sanitizeData()` before calling `console.log`.
✅ Verification: Verify that the console logs for network requests mask properties like "password", "token", "cpf", and "email".

---
*PR created automatically by Jules for task [10637734774797367107](https://jules.google.com/task/10637734774797367107) started by @mateuscarlos*