### PR TITLE
⚡ Bolt: Consolidate multiple .filter() calls in data fetching hooks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-02-18 - Nested Suspense for Layouts
 **Learning:** Placing a `Suspense` boundary inside the Layout component (wrapping `Outlet`) instead of just at the top level allows the sidebar/header to remain visible while the page content loads.
 **Action:** Identify Layout components and wrap their `Outlet` in `Suspense` to avoid "white screen" flashes during navigation.
+
+## 2024-03-10 - Consolidate Multiple Array Iterations
+**Learning:** Chaining multiple `.filter()` calls on arrays of mock data (or cached local state) is a common anti-pattern that creates intermediate arrays and requires O(K*N) passes (where K is the number of filters).
+**Action:** When working on data filtering hooks (e.g., `useUsers`, `useInventory`), consolidate multiple conditions into a single pass using early returns inside a single `.filter()` call. This significantly reduces CPU overhead and intermediate array memory allocations.

--- a/src/modules/inventory/presentation/hooks/useInventory.ts
+++ b/src/modules/inventory/presentation/hooks/useInventory.ts
@@ -18,27 +18,26 @@ export function useInventoryItems(filters: InventoryFilters = {}) {
       if (ENV.ENABLE_MOCK_DATA) {
         await new Promise(resolve => setTimeout(resolve, 400));
         
-        let filtered = [...mockInventoryItems];
-        
-        if (filters.search) {
-          const search = filters.search.toLowerCase();
-          filtered = filtered.filter(i => 
+        // ⚡ Bolt: Consolidated multiple .filter() calls into a single pass to reduce intermediate array allocations and O(K*N) iterations
+        const search = filters.search?.toLowerCase();
+        const filtered = mockInventoryItems.filter(i => {
+          if (search && !(
             i.name.toLowerCase().includes(search) ||
             i.code.toLowerCase().includes(search)
-          );
-        }
-        
-        if (filters.category) {
-          filtered = filtered.filter(i => i.category === filters.category);
-        }
-        
-        if (filters.status) {
-          filtered = filtered.filter(i => i.status === filters.status);
-        }
-        
-        if (filters.lowStock) {
-          filtered = filtered.filter(i => i.quantity <= i.minQuantity);
-        }
+          )) {
+            return false;
+          }
+          if (filters.category && i.category !== filters.category) {
+            return false;
+          }
+          if (filters.status && i.status !== filters.status) {
+            return false;
+          }
+          if (filters.lowStock && i.quantity > i.minQuantity) {
+            return false;
+          }
+          return true;
+        });
         
         return {
           data: filtered,

--- a/src/modules/patients/presentation/hooks/usePatients.ts
+++ b/src/modules/patients/presentation/hooks/usePatients.ts
@@ -25,20 +25,21 @@ export function usePatients(filters: PatientFilters = {}) {
         await new Promise(resolve => setTimeout(resolve, 500));
         
         // Filtrar dados mockados
-        let filtered = [...mockPatients];
-        
-        if (filters.search) {
-          const search = filters.search.toLowerCase();
-          filtered = filtered.filter(p => 
+        // ⚡ Bolt: Consolidated multiple .filter() calls into a single pass to reduce intermediate array allocations and O(K*N) iterations
+        const search = filters.search?.toLowerCase();
+        const filtered = mockPatients.filter(p => {
+          if (search && !(
             p.name.toLowerCase().includes(search) ||
             p.medicalRecordNumber.toLowerCase().includes(search) ||
             p.cpf.includes(search)
-          );
-        }
-        
-        if (filters.status) {
-          filtered = filtered.filter(p => p.status === filters.status);
-        }
+          )) {
+            return false;
+          }
+          if (filters.status && p.status !== filters.status) {
+            return false;
+          }
+          return true;
+        });
         
         return {
           data: filtered,

--- a/src/modules/reports/presentation/hooks/useReports.ts
+++ b/src/modules/reports/presentation/hooks/useReports.ts
@@ -18,15 +18,16 @@ export function useReports(filters: ReportFilters = {}) {
       if (ENV.ENABLE_MOCK_DATA) {
         await new Promise(resolve => setTimeout(resolve, 400));
         
-        let filtered = [...mockReports];
-        
-        if (filters.type) {
-          filtered = filtered.filter(r => r.type === filters.type);
-        }
-        
-        if (filters.period) {
-          filtered = filtered.filter(r => r.period === filters.period);
-        }
+        // ⚡ Bolt: Consolidated multiple .filter() calls into a single pass to reduce intermediate array allocations and O(K*N) iterations
+        const filtered = mockReports.filter(r => {
+          if (filters.type && r.type !== filters.type) {
+            return false;
+          }
+          if (filters.period && r.period !== filters.period) {
+            return false;
+          }
+          return true;
+        });
         
         return {
           data: filtered,

--- a/src/modules/users/presentation/hooks/useUsers.ts
+++ b/src/modules/users/presentation/hooks/useUsers.ts
@@ -18,24 +18,24 @@ export function useUsers(filters: UserFilters = {}) {
       if (ENV.ENABLE_MOCK_DATA) {
         await new Promise(resolve => setTimeout(resolve, 400));
         
-        let filtered = [...mockUsers];
-        
-        if (filters.search) {
-          const search = filters.search.toLowerCase();
-          filtered = filtered.filter(u => 
+        // ⚡ Bolt: Consolidated multiple .filter() calls into a single pass to reduce intermediate array allocations and O(K*N) iterations
+        const search = filters.search?.toLowerCase();
+        const filtered = mockUsers.filter(u => {
+          if (search && !(
             u.name.toLowerCase().includes(search) ||
             u.email.toLowerCase().includes(search) ||
             u.cpf.includes(search)
-          );
-        }
-        
-        if (filters.role) {
-          filtered = filtered.filter(u => u.role === filters.role);
-        }
-        
-        if (filters.status) {
-          filtered = filtered.filter(u => u.status === filters.status);
-        }
+          )) {
+            return false;
+          }
+          if (filters.role && u.role !== filters.role) {
+            return false;
+          }
+          if (filters.status && u.status !== filters.status) {
+            return false;
+          }
+          return true;
+        });
         
         return {
           data: filtered,


### PR DESCRIPTION
💡 **What:** Consolidated chained `.filter()` calls into a single array iteration with early returns in `useUsers`, `useInventory`, `usePatients`, and `useReports` hooks.

🎯 **Why:** Multiple consecutive `.filter()` calls iterate over the dataset multiple times (O(K*N), where K is the number of filters) and create intermediate arrays in memory for each step. This causes unnecessary garbage collection and CPU overhead, especially as the lists grow.

📊 **Impact:** Reduces array iteration overhead to O(N) and eliminates the creation of multiple intermediate arrays, saving memory allocations per hook execution when filters are active.

🔬 **Measurement:** You can verify the functional correctness by applying filters on the Users, Inventory, Patients, and Reports pages. The results will be exactly the same as before but execute more efficiently in local/mock environments.

---
*PR created automatically by Jules for task [6039488008453004960](https://jules.google.com/task/6039488008453004960) started by @mateuscarlos*