### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,7 +154,7 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
+              <Button variant="ghost" size="icon" aria-label="Abrir menu de navegação">
                 <Menu className="h-6 w-6" />
               </Button>
             </SheetTrigger>

--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -221,6 +221,7 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                     size="icon"
                     onClick={handleFetchAddress}
                     disabled={loadingCep}
+                    aria-label="Buscar endereço pelo CEP"
                   >
                     {loadingCep ? (
                       <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/pages/Patients.tsx
+++ b/src/pages/Patients.tsx
@@ -80,7 +80,7 @@ const Patients = () => {
                   className="pl-9 w-[200px] lg:w-[300px]"
                 />
               </div>
-              <Button variant="outline" size="icon">
+              <Button variant="outline" size="icon" aria-label="Filtros">
                 <Filter className="h-4 w-4" />
               </Button>
             </div>

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -39,7 +39,7 @@ const UsersPage = () => {
                   <Shield className="h-4 w-4" />
                   {user.type}
                 </div>
-                <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+                <Button variant="ghost" size="sm" className="h-8 w-8 p-0" aria-label="Editar usuário">
                   <UserCog className="h-4 w-4" />
                 </Button>
               </div>


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes to several icon-only buttons across the application (Mobile Menu, CEP Search, Filters, and User Edit buttons).
🎯 **Why:** Icon-only buttons without accessible names are invisible or read confusingly by screen readers. Adding `aria-label`s makes these crucial interactions accessible to all users.
♿ **Accessibility:** Improved screen reader support for navigation, forms, and actions.
📸 **Before/After:** The changes are invisible visually but immediately make the DOM accessible.

---
*PR created automatically by Jules for task [14568147598026757751](https://jules.google.com/task/14568147598026757751) started by @mateuscarlos*