### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and Tooltips to icon-only buttons

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/shared/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/shared/ui/sheet";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { cn } from "@/shared/utils/cn";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/shared/ui/collapsible";
 
@@ -153,11 +154,18 @@ const AppLayout = () => {
           </div>
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
-            <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
-              </Button>
-            </SheetTrigger>
+            <Tooltip>
+              <SheetTrigger asChild>
+                <TooltipTrigger asChild>
+                  <Button variant="ghost" size="icon" aria-label="Abrir menu">
+                    <Menu className="h-6 w-6" aria-hidden="true" />
+                  </Button>
+                </TooltipTrigger>
+              </SheetTrigger>
+              <TooltipContent>
+                <p>Abrir menu</p>
+              </TooltipContent>
+            </Tooltip>
             <SheetContent side="left" className="p-0 w-64">
               <Sidebar onClose={() => setIsMobileOpen(false)} />
             </SheetContent>

--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -15,6 +15,7 @@ import { maskCPF, maskCEP, maskPhone, unmaskCPF, unmaskCEP, unmaskPhone } from '
 import { ConfirmationDialog } from '@/shared/ui/confirmation-dialog';
 import { Button } from '@/shared/ui/button';
 import { Input } from '@/shared/ui/input';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
 import { Label } from '@/shared/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select';
 import { Textarea } from '@/shared/ui/textarea';
@@ -215,19 +216,27 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                       setValue('zipCode', unmaskCEP(masked));
                     }}
                   />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    onClick={handleFetchAddress}
-                    disabled={loadingCep}
-                  >
-                    {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Search className="h-4 w-4" />
-                    )}
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={handleFetchAddress}
+                        disabled={loadingCep}
+                        aria-label="Buscar endereço por CEP"
+                      >
+                        {loadingCep ? (
+                          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                        ) : (
+                          <Search className="h-4 w-4" aria-hidden="true" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Buscar endereço</p>
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 {errors.zipCode && (
                   <p className="text-sm text-destructive">{errors.zipCode.message}</p>


### PR DESCRIPTION
💡 **What**: Added `Tooltip`, `aria-label`, and `aria-hidden` tags to icon-only buttons across the application (specifically the mobile menu button and the fetch CEP search button).
🎯 **Why**: Icon-only buttons without `aria-label`s are completely invisible/unusable to screen readers, and without Tooltips, their meaning can be ambiguous to sighted users. Adding these improves both accessibility and general usability.
📸 **Before/After**: See verified screenshots in verification workflow.
♿ **Accessibility**: Fixed missing ARIA labels on `AppLayout` menu toggle and `PatientForm` CEP fetch. Added `aria-hidden="true"` to decorative Lucide React icons.

---
*PR created automatically by Jules for task [3282186475221463931](https://jules.google.com/task/3282186475221463931) started by @mateuscarlos*