### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,8 +154,8 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
+              <Button variant="ghost" size="icon" aria-label="Abrir menu">
+                <Menu className="h-6 w-6" aria-hidden="true" />
               </Button>
             </SheetTrigger>
             <SheetContent side="left" className="p-0 w-64">

--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -221,11 +221,12 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                     size="icon"
                     onClick={handleFetchAddress}
                     disabled={loadingCep}
+                    aria-label="Buscar endereço pelo CEP"
                   >
                     {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
                     ) : (
-                      <Search className="h-4 w-4" />
+                      <Search className="h-4 w-4" aria-hidden="true" />
                     )}
                   </Button>
                 </div>

--- a/src/pages/Patients.tsx
+++ b/src/pages/Patients.tsx
@@ -80,8 +80,8 @@ const Patients = () => {
                   className="pl-9 w-[200px] lg:w-[300px]"
                 />
               </div>
-              <Button variant="outline" size="icon">
-                <Filter className="h-4 w-4" />
+              <Button variant="outline" size="icon" aria-label="Filtrar pacientes">
+                <Filter className="h-4 w-4" aria-hidden="true" />
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## 💡 What
Added `aria-label` attributes to several icon-only buttons across the application and `aria-hidden="true"` to their respective inner SVG icons.

The modified elements include:
- The mobile hamburger menu button in `AppLayout.tsx`.
- The search address by CEP button in `PatientForm.tsx`.
- The filter toggle button in `Patients.tsx`.

## 🎯 Why
Icon-only buttons rely entirely on visual cues to convey their purpose. Without an accessible name, screen readers announce these buttons simply as "button", leaving visually impaired users with no context about what the button does.

## 📸 Before/After
**Before:** Screen readers would announce "button" and then try to interpret the SVG elements.
**After:** Screen readers announce meaningful names like "Abrir menu", "Buscar endereço pelo CEP", and "Filtrar pacientes", skipping the redundant SVG descriptions.

## ♿ Accessibility
- **WCAG 4.1.2 Name, Role, Value:** By providing explicit `aria-label`s, we ensure these interactive controls have an accessible name programmatically determinable by assistive technologies.
- Adding `aria-hidden="true"` to purely decorative SVGs inside actionable elements prevents screen readers from redundantly announcing the icons, reducing cognitive load and providing a cleaner auditory experience.

---
*PR created automatically by Jules for task [5014879201189006706](https://jules.google.com/task/5014879201189006706) started by @mateuscarlos*