### PR TITLE
🎨 Palette: Improve accessibility of mobile menu button

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/shared/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/shared/ui/sheet";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/shared/ui/tooltip";
 import { cn } from "@/shared/utils/cn";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/shared/ui/collapsible";
 
@@ -153,11 +154,18 @@ const AppLayout = () => {
           </div>
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
-            <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
-              </Button>
-            </SheetTrigger>
+            <Tooltip>
+              <SheetTrigger asChild>
+                <TooltipTrigger asChild>
+                  <Button variant="ghost" size="icon" aria-label="Abrir menu">
+                    <Menu className="h-6 w-6" aria-hidden="true" />
+                  </Button>
+                </TooltipTrigger>
+              </SheetTrigger>
+              <TooltipContent>
+                <p>Abrir menu</p>
+              </TooltipContent>
+            </Tooltip>
             <SheetContent side="left" className="p-0 w-64">
               <Sidebar onClose={() => setIsMobileOpen(false)} />
             </SheetContent>


### PR DESCRIPTION
💡 What: Added an `aria-label` and a Tooltip component to the mobile menu hamburger button in `AppLayout.tsx`.
🎯 Why: Icon-only buttons are invisible to screen readers without labels. The tooltip helps sighted users, while the `aria-label` provides a descriptive name for AT users. 
📸 Before/After: Screenshot of tooltip rendering correctly generated.
♿ Accessibility: Improved screen reader support and general usability.

---
*PR created automatically by Jules for task [1531494019325055126](https://jules.google.com/task/1531494019325055126) started by @mateuscarlos*