### PR TITLE
🎨 Palette: Improve accessibility and UX of CEP search button

### DIFF
--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -20,6 +20,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Textarea } from '@/shared/ui/textarea';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card';
 import { useToast } from '@/shared/hooks/use-toast';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
 
 interface PatientFormProps {
   onSubmit: (data: PatientFormData) => void;
@@ -215,19 +216,27 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                       setValue('zipCode', unmaskCEP(masked));
                     }}
                   />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    onClick={handleFetchAddress}
-                    disabled={loadingCep}
-                  >
-                    {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Search className="h-4 w-4" />
-                    )}
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={handleFetchAddress}
+                        disabled={loadingCep}
+                        aria-label="Buscar endereço pelo CEP"
+                      >
+                        {loadingCep ? (
+                          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                        ) : (
+                          <Search className="h-4 w-4" aria-hidden="true" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Buscar CEP</p>
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 {errors.zipCode && (
                   <p className="text-sm text-destructive">{errors.zipCode.message}</p>


### PR DESCRIPTION
### 💡 What
Enhanced the accessibility and usability of the icon-only "CEP Search" button in the `PatientForm`.

### 🎯 Why
Icon-only buttons are invisible to screen readers without an `aria-label`, leaving visually impaired users unsure of what the button next to the input does. Additionally, adding a visual tooltip clarifies the button's action ("Buscar CEP") for sighted users who might not recognize the magnifying glass icon as a specialized search trigger.

### ♿ Accessibility
- Added `aria-label="Buscar endereço pelo CEP"` to the `<Button>`.
- Added `aria-hidden="true"` to the inner decorative `<Search />` and `<Loader2 />` icons.
- Wrapped the element in a standard `<Tooltip>` component for mouse and keyboard focus visibility.

---
*PR created automatically by Jules for task [8342119042547797883](https://jules.google.com/task/8342119042547797883) started by @mateuscarlos*