### PR TITLE
🎨 Palette: Add missing ARIA labels to icon-only buttons

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,8 +154,8 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
+              <Button variant="ghost" size="icon" aria-label="Abrir menu">
+                <Menu className="h-6 w-6" aria-hidden="true" />
               </Button>
             </SheetTrigger>
             <SheetContent side="left" className="p-0 w-64">

--- a/src/pages/Patients.tsx
+++ b/src/pages/Patients.tsx
@@ -80,8 +80,8 @@ const Patients = () => {
                   className="pl-9 w-[200px] lg:w-[300px]"
                 />
               </div>
-              <Button variant="outline" size="icon">
-                <Filter className="h-4 w-4" />
+              <Button variant="outline" size="icon" aria-label="Filtros">
+                <Filter className="h-4 w-4" aria-hidden="true" />
               </Button>
             </div>
           </div>


### PR DESCRIPTION
💡 **What:** Added `aria-label` to the mobile menu button in `AppLayout.tsx` ("Abrir menu") and the filter button in `Patients.tsx` ("Filtros"). Also added `aria-hidden="true"` to their respective icons (`Menu` and `Filter`).
🎯 **Why:** Icon-only buttons without accessible names are invisible to screen readers, making it impossible for users relying on assistive technologies to understand their purpose. This small change ensures everyone can navigate and use the filters.
📸 **Before/After:** The visual experience is unchanged, but the screen reader experience is now descriptive instead of silent.
♿ **Accessibility:** Fixes missing ARIA labels on critical navigation and filtering controls.

---
*PR created automatically by Jules for task [14755338291195974529](https://jules.google.com/task/14755338291195974529) started by @mateuscarlos*