### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and Tooltips to icon-only buttons

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,8 +154,8 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
+              <Button variant="ghost" size="icon" aria-label="Abrir menu de navegação">
+                <Menu className="h-6 w-6" aria-hidden="true" />
               </Button>
             </SheetTrigger>
             <SheetContent side="left" className="p-0 w-64">

--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -20,6 +20,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Textarea } from '@/shared/ui/textarea';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card';
 import { useToast } from '@/shared/hooks/use-toast';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
 
 interface PatientFormProps {
   onSubmit: (data: PatientFormData) => void;
@@ -215,19 +216,27 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                       setValue('zipCode', unmaskCEP(masked));
                     }}
                   />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    onClick={handleFetchAddress}
-                    disabled={loadingCep}
-                  >
-                    {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Search className="h-4 w-4" />
-                    )}
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={handleFetchAddress}
+                        disabled={loadingCep}
+                        aria-label="Buscar endereço por CEP"
+                      >
+                        {loadingCep ? (
+                          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                        ) : (
+                          <Search className="h-4 w-4" aria-hidden="true" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Buscar endereço por CEP</p>
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 {errors.zipCode && (
                   <p className="text-sm text-destructive">{errors.zipCode.message}</p>

--- a/src/pages/Patients.tsx
+++ b/src/pages/Patients.tsx
@@ -8,6 +8,7 @@ import { ScrollArea } from "@/shared/ui/scroll-area";
 import { PatientForm } from "@/modules/patients/presentation/components/PatientForm";
 import { PatientFormData } from "@/modules/patients/presentation/forms/PatientFormSchema";
 import { useToast } from "@/shared/hooks/use-toast";
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
 
 const Patients = () => {
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -80,9 +81,16 @@ const Patients = () => {
                   className="pl-9 w-[200px] lg:w-[300px]"
                 />
               </div>
-              <Button variant="outline" size="icon">
-                <Filter className="h-4 w-4" />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" aria-label="Filtros">
+                    <Filter className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Filtros</p>
+                </TooltipContent>
+              </Tooltip>
             </div>
           </div>
         </CardHeader>


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `aria-hidden` to the mobile menu toggle button, the CEP search button, and the Patient filter button. Additionally wrapped the latter two in visual `Tooltip` components.
🎯 **Why:** Icon-only buttons are invisible to screen readers without descriptive labels. Decorative icons inside them should be hidden to avoid redundant readouts. Visual tooltips help sighted users understand the button's purpose without guessing. 
📸 **Before/After:** See the attached visual verifications.
♿ **Accessibility:** Screen readers will now announce the exact function of these three critical icon buttons instead of just "button".

---
*PR created automatically by Jules for task [4970840290587870327](https://jules.google.com/task/4970840290587870327) started by @mateuscarlos*