### PR TITLE
🎨 Palette: Add Tooltip and ARIA label to CEP search button

### DIFF
--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -20,6 +20,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Textarea } from '@/shared/ui/textarea';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card';
 import { useToast } from '@/shared/hooks/use-toast';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
 
 interface PatientFormProps {
   onSubmit: (data: PatientFormData) => void;
@@ -215,19 +216,27 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                       setValue('zipCode', unmaskCEP(masked));
                     }}
                   />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    onClick={handleFetchAddress}
-                    disabled={loadingCep}
-                  >
-                    {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Search className="h-4 w-4" />
-                    )}
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={handleFetchAddress}
+                        disabled={loadingCep}
+                        aria-label="Buscar endereço por CEP"
+                      >
+                        {loadingCep ? (
+                          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                        ) : (
+                          <Search className="h-4 w-4" aria-hidden="true" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Buscar endereço</p>
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 {errors.zipCode && (
                   <p className="text-sm text-destructive">{errors.zipCode.message}</p>

--- a/src/modules/patients/presentation/pages/PatientsPage.tsx
+++ b/src/modules/patients/presentation/pages/PatientsPage.tsx
@@ -102,14 +102,6 @@ export function PatientsPage() {
         </CardContent>
       </Card>
 
-      {/* Patient List */}
-      <Card>
-        <CardHeader className="pb-3">
-          <div className="flex items-center justify-between">
-            <CardTitle>Lista de Pacientes</CardTitle>
-            {data?.pagination && (
-              <span className="text-sm text-muted-foreground">
-
       {/* Modal do Formulário de Cadastro */}
       <Dialog open={isFormOpen} onOpenChange={setIsFormOpen}>
         <DialogContent className="max-w-5xl max-h-[90vh] p-0">
@@ -129,6 +121,14 @@ export function PatientsPage() {
           </ScrollArea>
         </DialogContent>
       </Dialog>
+
+      {/* Patient List */}
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between">
+            <CardTitle>Lista de Pacientes</CardTitle>
+            {data?.pagination && (
+              <span className="text-sm text-muted-foreground">
                 {data.pagination.total} paciente{data.pagination.total !== 1 ? 's' : ''} encontrado{data.pagination.total !== 1 ? 's' : ''}
               </span>
             )}


### PR DESCRIPTION
💡 What: Added a Tooltip and `aria-label` to the "Search CEP" icon button in the new patient form. Additionally fixed a bug where the form modal could not be opened if the patient list was empty because it was nested inside a conditionally rendered pagination span.

🎯 Why: Icon-only buttons are confusing for sighted users without tooltips and invisible to screen-reader users without ARIA labels.

📸 Before/After: The button now reveals "Buscar endereço" on hover and announces correctly.

♿ Accessibility: Added `aria-label="Buscar endereço por CEP"` and set `aria-hidden="true"` on the interior `<Search>` and `<Loader2>` icons to avoid redundant announcements.

---
*PR created automatically by Jules for task [12497434792422198638](https://jules.google.com/task/12497434792422198638) started by @mateuscarlos*