### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,8 +154,8 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
+              <Button variant="ghost" size="icon" aria-label="Abrir menu">
+                <Menu className="h-6 w-6" aria-hidden="true" />
               </Button>
             </SheetTrigger>
             <SheetContent side="left" className="p-0 w-64">

--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -219,13 +219,14 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                     type="button"
                     variant="outline"
                     size="icon"
+                    aria-label="Buscar endereço por CEP"
                     onClick={handleFetchAddress}
                     disabled={loadingCep}
                   >
                     {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
                     ) : (
-                      <Search className="h-4 w-4" />
+                      <Search className="h-4 w-4" aria-hidden="true" />
                     )}
                   </Button>
                 </div>

--- a/src/pages/Patients.tsx
+++ b/src/pages/Patients.tsx
@@ -73,15 +73,15 @@ const Patients = () => {
             <CardTitle>Lista de Pacientes</CardTitle>
             <div className="flex gap-2">
               <div className="relative w-full max-w-sm">
-                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-gray-500" />
+                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-gray-500" aria-hidden="true" />
                 <Input
                   type="search"
                   placeholder="Buscar paciente..."
                   className="pl-9 w-[200px] lg:w-[300px]"
                 />
               </div>
-              <Button variant="outline" size="icon">
-                <Filter className="h-4 w-4" />
+              <Button variant="outline" size="icon" aria-label="Filtros">
+                <Filter className="h-4 w-4" aria-hidden="true" />
               </Button>
             </div>
           </div>


### PR DESCRIPTION
💡 **What:** Added missing `aria-label` attributes to several icon-only buttons across the application and applied `aria-hidden="true"` to their nested decorative icons.

🎯 **Why:** Icon-only buttons (using `size="icon"`) lack visible text, making them completely invisible or confusing to screen reader users without an accessible name. Adding `aria-label` provides the necessary context, and hiding the inner decorative icons prevents redundant or confusing announcements.

📸 **Before/After:** No visual changes. This is purely an accessibility improvement at the DOM/ARIA level.

♿ **Accessibility:**
- Added `aria-label="Abrir menu"` to the mobile menu toggle button in `AppLayout`.
- Added `aria-label="Filtros"` to the filter toggle button in `Patients`.
- Added `aria-label="Buscar endereço por CEP"` to the fetch address search button in `PatientForm`.
- Added `aria-hidden="true"` to the corresponding nested `Menu`, `Filter`, `Search`, and `Loader2` SVG icons to avoid redundant structural announcements by assistive technologies.

---
*PR created automatically by Jules for task [3766593208000182598](https://jules.google.com/task/3766593208000182598) started by @mateuscarlos*