### PR TITLE
🎨 Palette: [Accessibility] Add ARIA label to mobile menu button

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,8 +154,8 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
+              <Button variant="ghost" size="icon" aria-label="Abrir menu">
+                <Menu className="h-6 w-6" aria-hidden="true" />
               </Button>
             </SheetTrigger>
             <SheetContent side="left" className="p-0 w-64">


### PR DESCRIPTION
💡 **What:** Added an `aria-label` ("Abrir menu") to the icon-only mobile menu `<Button>`, and an `aria-hidden="true"` attribute to the `<Menu />` SVG icon.
🎯 **Why:** Icon-only buttons are completely invisible to screen readers without an explicit label. Additionally, applying `aria-hidden="true"` to the decorative icon ensures screen readers do not redundantly attempt to announce the SVG element itself, providing a much cleaner and accessible experience for Assistive Technology users. 
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Fixes a critical accessibility gap on the mobile layout navigation where screen-reader users previously had no context for the hamburger menu.

---
*PR created automatically by Jules for task [5907859544172104192](https://jules.google.com/task/5907859544172104192) started by @mateuscarlos*