### PR TITLE
🎨 Palette: Adicionar aria-label ao menu mobile

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,7 @@
 ## 2025-01-26 - Icon-Only Button Accessibility
 **Learning:** Icon-only buttons are invisible to screen readers without labels. Tooltips alone are insufficient for AT users.
 **Action:** Pair `Tooltip` (for sighted users) with `aria-label` (for AT users) on every icon button.
+
+## 2025-01-27 - Mobile Header Accessibility
+**Learning:** Hamburger menu icon buttons in responsive mobile headers often lack text descriptions, making them invisible to screen readers since there's no visible tooltip equivalent.
+**Action:** Always add `aria-label` to the wrapper button and `aria-hidden="true"` to the inner SVG icon when building mobile navigation toggles.

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,8 +154,8 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
+              <Button variant="ghost" size="icon" aria-label="Abrir menu">
+                <Menu className="h-6 w-6" aria-hidden="true" />
               </Button>
             </SheetTrigger>
             <SheetContent side="left" className="p-0 w-64">


### PR DESCRIPTION
💡 **What:** Added `aria-label="Abrir menu"` to the mobile header hamburger menu button and `aria-hidden="true"` to the `Menu` icon within `src/components/layout/AppLayout.tsx`.
🎯 **Why:** The icon-only hamburger button lacked an accessible name, making it invisible or confusing for users relying on screen readers.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now announce "Abrir menu" instead of reading nothing or a generic "button", while correctly ignoring the decorative SVG element.

---
*PR created automatically by Jules for task [4423040380756922609](https://jules.google.com/task/4423040380756922609) started by @mateuscarlos*