### PR TITLE
🎨 Palette: Icon-only button accessibility and tooltips

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,7 +154,7 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
+              <Button variant="ghost" size="icon" aria-label="Abrir menu">
                 <Menu className="h-6 w-6" />
               </Button>
             </SheetTrigger>

--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -17,6 +17,7 @@ import { Button } from '@/shared/ui/button';
 import { Input } from '@/shared/ui/input';
 import { Label } from '@/shared/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
 import { Textarea } from '@/shared/ui/textarea';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card';
 import { useToast } from '@/shared/hooks/use-toast';
@@ -215,19 +216,27 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                       setValue('zipCode', unmaskCEP(masked));
                     }}
                   />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    onClick={handleFetchAddress}
-                    disabled={loadingCep}
-                  >
-                    {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Search className="h-4 w-4" />
-                    )}
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={handleFetchAddress}
+                        disabled={loadingCep}
+                        aria-label="Buscar endereço pelo CEP"
+                      >
+                        {loadingCep ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Search className="h-4 w-4" aria-hidden="true" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Buscar endereço pelo CEP</p>
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 {errors.zipCode && (
                   <p className="text-sm text-destructive">{errors.zipCode.message}</p>


### PR DESCRIPTION
💡 **What:** Added `aria-label` to the mobile hamburger menu in the AppLayout and wrapped the CEP search button in the PatientForm with a `Tooltip` and `aria-label`.

🎯 **Why:** Icon-only buttons are invisible to screen readers without labels. Furthermore, adding a tooltip to the CEP search helps sighted users understand the action before clicking, improving the overall UX of the form. The hamburger menu on mobile cannot use a hover tooltip, so just an `aria-label` is sufficient.

📸 **Before/After:**
- **Before:** The CEP button only showed a magnifying glass icon. The mobile menu button had no label.
- **After:** The CEP button shows a tooltip saying "Buscar endereço pelo CEP" on hover/focus and screen readers announce both buttons correctly.

♿ **Accessibility:**
- Added `aria-label="Abrir menu"` to the mobile menu button.
- Added `aria-label="Buscar endereço pelo CEP"` and a `Tooltip` to the CEP search button.
- Ensured decorative `Search` icon has `aria-hidden="true"`.

---
*PR created automatically by Jules for task [11655438539552916081](https://jules.google.com/task/11655438539552916081) started by @mateuscarlos*