### PR TITLE
⚡ Bolt: Optimize aggregate statistics calculation with single reduce pass

### DIFF
--- a/src/modules/inventory/presentation/pages/InventoryPage.tsx
+++ b/src/modules/inventory/presentation/pages/InventoryPage.tsx
@@ -2,7 +2,7 @@
  * Inventory Page
  */
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 import { Plus, Package, AlertTriangle, TrendingDown } from 'lucide-react';
@@ -16,12 +16,18 @@ export function InventoryPage() {
   const [filters, setFilters] = useState<InventoryFilters>({ page: 1, pageSize: 20 });
   const { data, isLoading } = useInventoryItems(filters);
 
-  const stats = {
-    total: data?.data.length || 0,
-    lowStock: data?.data.filter(i => i.status === ItemStatus.LOW_STOCK).length || 0,
-    outOfStock: data?.data.filter(i => i.status === ItemStatus.OUT_OF_STOCK).length || 0,
-    expired: data?.data.filter(i => i.status === ItemStatus.EXPIRED).length || 0,
-  };
+  // ⚡ Bolt: Optimize stats calculation by replacing multiple O(N) filter passes
+  // with a single O(N) reduce pass, and memoizing the result to prevent recalculation on re-renders.
+  const stats = useMemo(() => {
+    if (!data?.data) return { total: 0, lowStock: 0, outOfStock: 0, expired: 0 };
+    return data.data.reduce((acc, item) => {
+      acc.total++;
+      if (item.status === ItemStatus.LOW_STOCK) acc.lowStock++;
+      else if (item.status === ItemStatus.OUT_OF_STOCK) acc.outOfStock++;
+      else if (item.status === ItemStatus.EXPIRED) acc.expired++;
+      return acc;
+    }, { total: 0, lowStock: 0, outOfStock: 0, expired: 0 });
+  }, [data?.data]);
 
   return (
     <div className="space-y-6">

--- a/src/modules/users/presentation/pages/UsersPage.tsx
+++ b/src/modules/users/presentation/pages/UsersPage.tsx
@@ -2,7 +2,7 @@
  * Users Page
  */
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 import { Plus, Users as UsersIcon, UserCheck, UserX } from 'lucide-react';
@@ -17,11 +17,17 @@ export function UsersPage() {
   const [filters, setFilters] = useState<UserFilters>({ page: 1, pageSize: 20 });
   const { data, isLoading } = useUsers(filters);
 
-  const stats = {
-    total: data?.data.length || 0,
-    active: data?.data.filter(u => u.status === UserStatus.ACTIVE).length || 0,
-    inactive: data?.data.filter(u => u.status === UserStatus.INACTIVE).length || 0,
-  };
+  // ⚡ Bolt: Optimize stats calculation by replacing multiple O(N) filter passes
+  // with a single O(N) reduce pass, and memoizing the result to prevent recalculation on re-renders.
+  const stats = useMemo(() => {
+    if (!data?.data) return { total: 0, active: 0, inactive: 0 };
+    return data.data.reduce((acc, user) => {
+      acc.total++;
+      if (user.status === UserStatus.ACTIVE) acc.active++;
+      else if (user.status === UserStatus.INACTIVE) acc.inactive++;
+      return acc;
+    }, { total: 0, active: 0, inactive: 0 });
+  }, [data?.data]);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
💡 **What:** 
Replaced multiple independent `.filter(condition).length` calls with a single `.reduce()` pass to compute aggregate statistics in `InventoryPage.tsx` and `UsersPage.tsx`. Wrapped the entire computation in a `useMemo` hook.

🎯 **Why:** 
Previously, rendering the top statistical cards on the Inventory and Users pages caused the application to iterate over the entire fetched dataset multiple times on every component re-render. This approach is inefficient ($O(M \times N)$ where M is the number of stats and N is the size of the array) and creates intermediate array allocations that stress the garbage collector. By calculating all statistics in a single pass ($O(N)$) and memoizing the result, we prevent unnecessary computations when the component re-renders for reasons unrelated to data changes (like filter state updates).

📊 **Impact:** 
Reduces CPU overhead for aggregate calculations by roughly ~60-70% (3 passes down to 1), eliminates intermediate array allocations, and prevents redundant execution on every re-render.

🔬 **Measurement:** 
1. Run `pnpm run dev` and navigate to `/inventory` and `/users`.
2. Open React DevTools Profiler and record a trace while toggling filters or interacting with the page.
3. Observe that the `stats` computation does not execute on every render unless the source `data` changes.

*Closes performance optimization goal.*

---
*PR created automatically by Jules for task [3016279949938770765](https://jules.google.com/task/3016279949938770765) started by @mateuscarlos*