### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,8 +154,8 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
+              <Button variant="ghost" size="icon" aria-label="Abrir menu de navegação">
+                <Menu className="h-6 w-6" aria-hidden="true" />
               </Button>
             </SheetTrigger>
             <SheetContent side="left" className="p-0 w-64">

--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -221,11 +221,12 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                     size="icon"
                     onClick={handleFetchAddress}
                     disabled={loadingCep}
+                    aria-label="Buscar endereço pelo CEP"
                   >
                     {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
                     ) : (
-                      <Search className="h-4 w-4" />
+                      <Search className="h-4 w-4" aria-hidden="true" />
                     )}
                   </Button>
                 </div>


### PR DESCRIPTION
### 💡 What:
Added missing `aria-label` attributes to icon-only buttons across the application, specifically the mobile menu button in `AppLayout.tsx` and the CEP search button in `PatientForm.tsx`. Also added `aria-hidden="true"` to the inner SVG icons.

### 🎯 Why:
Icon-only buttons are invisible to screen readers without proper labels. Adding `aria-label` ensures visually impaired users navigating via keyboard and screen reader understand the purpose of the button before interacting with it. `aria-hidden="true"` prevents the screen reader from pointlessly announcing the raw SVG element when a perfectly good label is already provided on the parent button.

### 📸 Before/After:
*Visually identical.*

**Before (Code):**
```tsx
<Button variant="ghost" size="icon">
  <Menu className="h-6 w-6" />
</Button>
```

**After (Code):**
```tsx
<Button variant="ghost" size="icon" aria-label="Abrir menu de navegação">
  <Menu className="h-6 w-6" aria-hidden="true" />
</Button>
```

### ♿ Accessibility:
*   Added `aria-label` to the mobile menu `<Button>`.
*   Added `aria-label` to the CEP search `<Button>`.
*   Added `aria-hidden="true"` to `<Menu>`, `<Search>`, and `<Loader2>` icons to avoid redundant announcements.

---
*PR created automatically by Jules for task [3814587852854692203](https://jules.google.com/task/3814587852854692203) started by @mateuscarlos*