### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix CSS Injection in ChartStyle

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The `.env` file containing environment variables (potentially secrets) was tracked in the git repository.
 **Learning:** Initial project setup or template generation failed to include `.env` in `.gitignore`, leading to accidental tracking of local configuration.
 **Prevention:** Always verify `.gitignore` includes sensitive file patterns (`.env`, `*.pem`, etc.) before the first commit. Use pre-commit hooks to scan for secrets.
+## 2024-05-23 - [CRITICAL] Fix CSS Injection in ChartStyle
+**Vulnerability:** The `ChartStyle` component used `dangerouslySetInnerHTML` to inject CSS dynamically, without sanitizing variables like `id` and `color`. This allows CSS injection attacks and potential XSS if a user has control over these properties.
+**Learning:** React elements can be vulnerable to XSS and CSS injection when passing unsanitized props into `<style>` tags using `dangerouslySetInnerHTML`.
+**Prevention:** Always sanitize dynamic inputs by stripping dangerous structural characters (e.g., `<>`, `[]`, `{}`, `;`, `"`, `'`) before injecting them into a DOM structure via `dangerouslySetInnerHTML`.

--- a/src/shared/ui/chart.tsx
+++ b/src/shared/ui/chart.tsx
@@ -74,19 +74,22 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
     return null;
   }
 
+  // eslint-disable-next-line no-useless-escape
+  const sanitize = (value: string) => value.replace(/[<>;}\[\]"']/g, "");
+
   return (
     <style
       dangerouslySetInnerHTML={{
         __html: Object.entries(THEMES)
           .map(
             ([theme, prefix]) => `
-${prefix} [data-chart=${id}] {
+${prefix} [data-chart=${sanitize(id)}] {
 ${colorConfig
   .map(([key, itemConfig]) => {
     const color =
       itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
       itemConfig.color;
-    return color ? `  --color-${key}: ${color};` : null;
+    return color ? `  --color-${sanitize(key)}: ${sanitize(color)};` : null;
   })
   .join("\n")}
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `ChartStyle` component used `dangerouslySetInnerHTML` to inject CSS dynamically without sanitizing the variables like `id`, `key`, or `color`. This could allow CSS injection attacks or XSS breakouts.
🎯 Impact: An attacker could potentially inject arbitrary CSS or break out of the `<style>` tag to execute malicious scripts if they have control over any of the injected values.
🔧 Fix: Introduced a `sanitize` helper function that strips out dangerous structural characters (`[<>;}\[\]"']`) using Regex before interpolation into `dangerouslySetInnerHTML`.
✅ Verification: Ensure the charts render normally. Inspect the source to ensure IDs and class names remain properly structured. Pre-commit tests (`pnpm lint`, `npx tsc --noEmit`) were run successfully.

---
*PR created automatically by Jules for task [6100981650116241381](https://jules.google.com/task/6100981650116241381) started by @mateuscarlos*