### PR TITLE
⚡ Bolt: Optimize aggregate stats calculation in InventoryPage

### DIFF
--- a/src/modules/inventory/presentation/pages/InventoryPage.tsx
+++ b/src/modules/inventory/presentation/pages/InventoryPage.tsx
@@ -2,7 +2,7 @@
  * Inventory Page
  */
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 import { Plus, Package, AlertTriangle, TrendingDown } from 'lucide-react';
@@ -16,12 +16,19 @@ export function InventoryPage() {
   const [filters, setFilters] = useState<InventoryFilters>({ page: 1, pageSize: 20 });
   const { data, isLoading } = useInventoryItems(filters);
 
-  const stats = {
-    total: data?.data.length || 0,
-    lowStock: data?.data.filter(i => i.status === ItemStatus.LOW_STOCK).length || 0,
-    outOfStock: data?.data.filter(i => i.status === ItemStatus.OUT_OF_STOCK).length || 0,
-    expired: data?.data.filter(i => i.status === ItemStatus.EXPIRED).length || 0,
-  };
+  // ⚡ Bolt: Calculate stats in a single O(N) pass and memoize to prevent redundant computation
+  const stats = useMemo(() => {
+    if (!data?.data) {
+      return { total: 0, lowStock: 0, outOfStock: 0, expired: 0 };
+    }
+    return data.data.reduce((acc, item) => {
+      acc.total++;
+      if (item.status === ItemStatus.LOW_STOCK) acc.lowStock++;
+      if (item.status === ItemStatus.OUT_OF_STOCK) acc.outOfStock++;
+      if (item.status === ItemStatus.EXPIRED) acc.expired++;
+      return acc;
+    }, { total: 0, lowStock: 0, outOfStock: 0, expired: 0 });
+  }, [data?.data]);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
**💡 What:** Replaced three separate `data?.data.filter(...).length` calls with a single `data.data.reduce(...)` pass and wrapped it in a `useMemo` hook in `InventoryPage.tsx`.

**🎯 Why:** The component was executing three separate array iteration passes (via `.filter`) on every render to calculate the count of items in different status states (Low Stock, Out of Stock, Expired). This was inefficient O(3N) and triggered unnecessarily on every state update. By reducing it to a single pass O(N) and memoizing it with `useMemo`, we save CPU cycles and prevent redundant intermediate array allocations.

**📊 Impact:** Reduces array iteration overhead by 66% and eliminates redundant computations entirely during unrelated component re-renders (like filter state updates). 

**🔬 Measurement:** Run the frontend development server and navigate to `/inventory`. The header statistics (Total de Itens, Estoque Baixo, Sem Estoque, Vencidos) will calculate and display correctly and exactly as they did before, matching the UI test and Playwright validation.

---
*PR created automatically by Jules for task [8143908838581213165](https://jules.google.com/task/8143908838581213165) started by @mateuscarlos*