### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons for accessibility

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,7 +154,7 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
+              <Button variant="ghost" size="icon" aria-label="Abrir menu de navegação">
                 <Menu className="h-6 w-6" />
               </Button>
             </SheetTrigger>

--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -219,6 +219,7 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                     type="button"
                     variant="outline"
                     size="icon"
+                    aria-label="Buscar endereço pelo CEP"
                     onClick={handleFetchAddress}
                     disabled={loadingCep}
                   >

--- a/src/pages/Patients.tsx
+++ b/src/pages/Patients.tsx
@@ -80,7 +80,7 @@ const Patients = () => {
                   className="pl-9 w-[200px] lg:w-[300px]"
                 />
               </div>
-              <Button variant="outline" size="icon">
+              <Button variant="outline" size="icon" aria-label="Filtrar pacientes">
                 <Filter className="h-4 w-4" />
               </Button>
             </div>


### PR DESCRIPTION
## 💡 What:
Added missing `aria-label` attributes to multiple icon-only buttons across the application (AppLayout mobile menu, PatientForm CEP search, and Patients page filter button).

## 🎯 Why:
Icon-only buttons are completely invisible to screen readers without an accessible name. This prevents visually impaired users from understanding what the button does or navigating the application effectively. Adding `aria-label`s makes these crucial interactions explicitly discoverable.

## 📸 Before/After:
Visually, the application remains identical.
In the DOM:
**Before:** `<button variant="outline" size="icon"><Search /></button>`
**After:** `<button variant="outline" size="icon" aria-label="Buscar endereço pelo CEP"><Search /></button>`

## ♿ Accessibility:
- Improves WCAG 2.1 compliance (Success Criterion 4.1.2 Name, Role, Value).
- Enables screen readers (like NVDA or VoiceOver) to announce the purpose of the buttons accurately in Portuguese ("Abrir menu de navegação", "Buscar endereço pelo CEP", "Filtrar pacientes").

---
*PR created automatically by Jules for task [11923794919377666508](https://jules.google.com/task/11923794919377666508) started by @mateuscarlos*