### PR TITLE
🎨 Palette: [UX improvement] Add ARIA label to mobile navigation menu button

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,8 +154,8 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
+              <Button variant="ghost" size="icon" aria-label="Abrir menu de navegação">
+                <Menu className="h-6 w-6" aria-hidden="true" />
               </Button>
             </SheetTrigger>
             <SheetContent side="left" className="p-0 w-64">


### PR DESCRIPTION
### 💡 What
Added an `aria-label` to the mobile hamburger menu `<Button>` and `aria-hidden="true"` to its inner `<Menu />` icon in `AppLayout.tsx`.

### 🎯 Why
Icon-only buttons are completely invisible to screen readers without proper labeling. The hamburger menu is a primary navigation element for mobile users, making it a critical interaction point that was previously inaccessible to users utilizing assistive technologies.

### 📸 Before/After
**Before:**
```tsx
<Button variant="ghost" size="icon">
  <Menu className="h-6 w-6" />
</Button>
```

**After:**
```tsx
<Button variant="ghost" size="icon" aria-label="Abrir menu de navegação">
  <Menu className="h-6 w-6" aria-hidden="true" />
</Button>
```

### ♿ Accessibility
- Screen readers will now explicitly announce the button's purpose as "Abrir menu de navegação" (matching the app's Portuguese localization).
- The `aria-hidden="true"` prevents screen readers from redundantly announcing the word "Menu" before or after the button label.

---
*PR created automatically by Jules for task [4072687586936588310](https://jules.google.com/task/4072687586936588310) started by @mateuscarlos*