### PR TITLE
⚡ Bolt: Optimize Insurers Page statistics calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2025-02-18 - Nested Suspense for Layouts
 **Learning:** Placing a `Suspense` boundary inside the Layout component (wrapping `Outlet`) instead of just at the top level allows the sidebar/header to remain visible while the page content loads.
 **Action:** Identify Layout components and wrap their `Outlet` in `Suspense` to avoid "white screen" flashes during navigation.
+## 2026-03-28 - Stop micro-optimizing mock data
+**Learning:** Optimizing array filtering logic inside mock data blocks (e.g., `if (ENV.ENABLE_MOCK_DATA)`) provides no real-world performance benefit and wastes effort, as this code is never run in production.
+**Action:** Always ensure performance optimizations target the actual production code paths, not local development mocks or test helpers. Review the surrounding context of the code being optimized.

--- a/src/pages/Insurers.tsx
+++ b/src/pages/Insurers.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { Button } from "@/shared/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/shared/ui/card";
 import { Badge } from "@/shared/ui/badge";
@@ -66,6 +66,23 @@ const InsurersPage = () => {
     }
   };
 
+  // ⚡ Bolt Performance Optimization:
+  // Pre-calculate aggregated stats in a single O(N) pass using useMemo.
+  // This avoids redundant .filter().length and .reduce() calls on every re-render.
+  const stats = useMemo(() => {
+    return insurers.reduce(
+      (acc, insurer) => {
+        acc.total += 1;
+        if (insurer.status === 'ACTIVE') {
+          acc.active += 1;
+        }
+        acc.totalPlans += insurer.plans?.length || 0;
+        return acc;
+      },
+      { total: 0, active: 0, totalPlans: 0 }
+    );
+  }, [insurers]);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
@@ -98,7 +115,7 @@ const InsurersPage = () => {
             <Building2 className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{insurers.length}</div>
+            <div className="text-2xl font-bold">{stats.total}</div>
             <p className="text-xs text-muted-foreground">Cadastradas no sistema</p>
           </CardContent>
         </Card>
@@ -109,9 +126,7 @@ const InsurersPage = () => {
             <Building2 className="h-4 w-4 text-green-600" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">
-              {insurers.filter(i => i.status === 'ACTIVE').length}
-            </div>
+            <div className="text-2xl font-bold">{stats.active}</div>
             <p className="text-xs text-muted-foreground">Com contratos ativos</p>
           </CardContent>
         </Card>
@@ -122,9 +137,7 @@ const InsurersPage = () => {
             <FileText className="h-4 w-4 text-blue-600" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">
-              {insurers.reduce((acc, insurer) => acc + insurer.plans.length, 0)}
-            </div>
+            <div className="text-2xl font-bold">{stats.totalPlans}</div>
             <p className="text-xs text-muted-foreground">Planos disponíveis</p>
           </CardContent>
         </Card>


### PR DESCRIPTION
💡 **What**: Replaced multiple array operations (`.length`, `.filter().length`, and `.reduce`) that calculated `InsurersPage` statistics on every render with a single `useMemo` block using a consolidated `.reduce()` pass.

🎯 **Why**: The previous implementation performed three separate O(N) passes over the `insurers` array on *every single React re-render*, recalculating values unnecessarily.

📊 **Impact**: Reduces time complexity of stats calculation from O(3N) to O(N) and ensures the calculation only executes when the `insurers` array actually changes, reducing CPU overhead during component re-renders.

🔬 **Measurement**: Inspect the `InsurersPage` component and observe that the stats calculation now only runs once when the `insurers` list loads, rather than executing on every render cycle.

---
*PR created automatically by Jules for task [6467775003396344337](https://jules.google.com/task/6467775003396344337) started by @mateuscarlos*