### PR TITLE
🎨 Palette: Improve Accessibility of Icon-Only Buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,7 @@
 ## 2025-01-26 - Icon-Only Button Accessibility
 **Learning:** Icon-only buttons are invisible to screen readers without labels. Tooltips alone are insufficient for AT users.
 **Action:** Pair `Tooltip` (for sighted users) with `aria-label` (for AT users) on every icon button.
+
+## 2025-03-29 - Mobile-Only Button Accessibility
+**Learning:** For mobile-only icon buttons (e.g., hamburger menus hidden on desktop), a `Tooltip` is unnecessary as mouse hover is unavailable.
+**Action:** Use an `aria-label` alone alongside `aria-hidden="true"` on the inner SVG for robust accessibility on mobile interaction patterns.

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,8 +154,8 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
+              <Button variant="ghost" size="icon" aria-label="Abrir menu">
+                <Menu className="h-6 w-6" aria-hidden="true" />
               </Button>
             </SheetTrigger>
             <SheetContent side="left" className="p-0 w-64">

--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -15,6 +15,7 @@ import { maskCPF, maskCEP, maskPhone, unmaskCPF, unmaskCEP, unmaskPhone } from '
 import { ConfirmationDialog } from '@/shared/ui/confirmation-dialog';
 import { Button } from '@/shared/ui/button';
 import { Input } from '@/shared/ui/input';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
 import { Label } from '@/shared/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select';
 import { Textarea } from '@/shared/ui/textarea';
@@ -215,19 +216,27 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                       setValue('zipCode', unmaskCEP(masked));
                     }}
                   />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    onClick={handleFetchAddress}
-                    disabled={loadingCep}
-                  >
-                    {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Search className="h-4 w-4" />
-                    )}
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={handleFetchAddress}
+                        disabled={loadingCep}
+                        aria-label="Buscar endereço por CEP"
+                      >
+                        {loadingCep ? (
+                          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                        ) : (
+                          <Search className="h-4 w-4" aria-hidden="true" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Buscar endereço</p>
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 {errors.zipCode && (
                   <p className="text-sm text-destructive">{errors.zipCode.message}</p>


### PR DESCRIPTION
💡 **What:** 
Added missing accessibility attributes (`aria-label`, `aria-hidden`) to two key icon-only buttons:
1. The mobile hamburger menu button in the main layout header (`AppLayout.tsx`).
2. The "Search CEP" (zip code lookup) button in the Patient Registration form (`PatientForm.tsx`), which was also wrapped in a `Tooltip` for sighted users.

🎯 **Why:** 
Icon-only buttons are invisible to screen readers unless they contain visually-hidden text or an `aria-label`. Without these labels, visually impaired users traversing the DOM hear "Button" with no context as to what the button actually does. On the Patient form, wrapping the search icon in a Tooltip also aids sighted users who might not immediately recognize the magnifying glass as a zip code lookup trigger.

📸 **Before/After:**
- **Before:** Mobile menu button rendered as `<button> <svg/> </button>`. CEP search rendered as `<button> <svg/> </button>`.
- **After:** Mobile menu button renders as `<button aria-label="Abrir menu"> <svg aria-hidden="true"/> </button>`. CEP search renders identically but is wrapped in a Shadcn `Tooltip` and includes `aria-label="Buscar endereço por CEP"`.

♿ **Accessibility:** 
- Adds `aria-label` to provide explicit accessible names to interactive elements lacking visible text content.
- Adds `aria-hidden="true"` to the decorative SVG elements to prevent screen readers from potentially attempting to announce internal SVG nodes or redundant titles.
- Exposes tooltip text for mouse users interacting with the search feature on desktop.

*Note: Added a critical learning to `.Jules/palette.md` noting that mobile-only buttons don't need Tooltips since hover is unavailable; an `aria-label` suffices.*

---
*PR created automatically by Jules for task [6979996181578191601](https://jules.google.com/task/6979996181578191601) started by @mateuscarlos*