### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon-only buttons

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,8 +154,8 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
+              <Button variant="ghost" size="icon" aria-label="Abrir menu de navegação">
+                <Menu className="h-6 w-6" aria-hidden="true" />
               </Button>
             </SheetTrigger>
             <SheetContent side="left" className="p-0 w-64">

--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -221,11 +221,12 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                     size="icon"
                     onClick={handleFetchAddress}
                     disabled={loadingCep}
+                    aria-label="Buscar endereço por CEP"
                   >
                     {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
                     ) : (
-                      <Search className="h-4 w-4" />
+                      <Search className="h-4 w-4" aria-hidden="true" />
                     )}
                   </Button>
                 </div>


### PR DESCRIPTION
## What
Added `aria-label` to icon-only buttons (`Menu` button in `AppLayout` and `Search` button in `PatientForm`) and `aria-hidden="true"` to their internal Lucide icons to prevent redundant screen reader announcements.

## Why
Icon-only buttons are invisible to screen readers without descriptive labels. These labels enable visually impaired users to understand and navigate actions successfully, following our design system a11y guidelines.

## Before/After
- **Before:** `<Button size="icon"><Menu /></Button>`
- **After:** `<Button size="icon" aria-label="Abrir menu de navegação"><Menu aria-hidden="true" /></Button>`

## Accessibility
Ensures screen reader friendly navigation for the sidebar toggle and address fetching via ViaCEP.

---
*PR created automatically by Jules for task [8279223752305597315](https://jules.google.com/task/8279223752305597315) started by @mateuscarlos*