### PR TITLE
⚡ Bolt: Optimize aggregate statistics calculation in inventory page

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-02-18 - Nested Suspense for Layouts
 **Learning:** Placing a `Suspense` boundary inside the Layout component (wrapping `Outlet`) instead of just at the top level allows the sidebar/header to remain visible while the page content loads.
 **Action:** Identify Layout components and wrap their `Outlet` in `Suspense` to avoid "white screen" flashes during navigation.
+
+## 2025-10-25 - Reducing redundant filter passes during React renders
+**Learning:** Replacing multiple independent `.filter().length` calls on the same array with a single `.reduce()` pass to calculate aggregate statistics is a key performance optimization that reduces complexity from O(MN) to O(N) and eliminates intermediate array allocations, yielding significant improvement on large datasets.
+**Action:** When calculating aggregate statistics (e.g., counts by status) from an array within a React component render cycle, replace multiple `.filter().length` statements with a single `.reduce()` pass and wrap the calculation in a `useMemo` hook.

--- a/src/modules/inventory/presentation/pages/InventoryPage.tsx
+++ b/src/modules/inventory/presentation/pages/InventoryPage.tsx
@@ -2,7 +2,7 @@
  * Inventory Page
  */
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 import { Plus, Package, AlertTriangle, TrendingDown } from 'lucide-react';
@@ -16,12 +16,23 @@ export function InventoryPage() {
   const [filters, setFilters] = useState<InventoryFilters>({ page: 1, pageSize: 20 });
   const { data, isLoading } = useInventoryItems(filters);
 
-  const stats = {
-    total: data?.data.length || 0,
-    lowStock: data?.data.filter(i => i.status === ItemStatus.LOW_STOCK).length || 0,
-    outOfStock: data?.data.filter(i => i.status === ItemStatus.OUT_OF_STOCK).length || 0,
-    expired: data?.data.filter(i => i.status === ItemStatus.EXPIRED).length || 0,
-  };
+  // ⚡ Bolt: Optimize aggregate statistics by replacing multiple O(N) filters with a single O(N) pass, wrapped in useMemo to prevent unnecessary recalculations
+  const stats = useMemo(() => {
+    if (!data?.data) {
+      return { total: 0, lowStock: 0, outOfStock: 0, expired: 0 };
+    }
+
+    return data.data.reduce(
+      (acc, item) => {
+        acc.total += 1;
+        if (item.status === ItemStatus.LOW_STOCK) acc.lowStock += 1;
+        if (item.status === ItemStatus.OUT_OF_STOCK) acc.outOfStock += 1;
+        if (item.status === ItemStatus.EXPIRED) acc.expired += 1;
+        return acc;
+      },
+      { total: 0, lowStock: 0, outOfStock: 0, expired: 0 }
+    );
+  }, [data?.data]);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
### 💡 What:
Replaced multiple independent `data?.data.filter(...).length` statements with a single `useMemo` block that uses `.reduce()` to calculate all aggregate statistics (`total`, `lowStock`, `outOfStock`, `expired`) simultaneously in one pass over the data array.

### 🎯 Why:
Calculating aggregate stats by iterating over the same array multiple times is an `O(M * N)` operation (where `M` is the number of filters and `N` is the length of the array) that allocates new intermediate arrays on every pass. Moving this to a single `.reduce()` pass brings it down to `O(N)` with no extra array allocations, and wrapping it in `useMemo` prevents the calculation from running unnecessarily on every React re-render (such as when state unrelated to `data.data` changes).

### 📊 Impact:
*   Reduces iterations over the inventory items array from 3 to 1.
*   Eliminates the creation of intermediate filtered arrays.
*   Prevents redundant calculation on arbitrary component re-renders by memoizing the result based on `data?.data`.

### 🔬 Measurement:
1.  Run the application locally using `pnpm dev`.
2.  Navigate to the `/inventory` route.
3.  Verify that the top statistic cards ("Total de Itens", "Estoque Baixo", "Sem Estoque", "Vencidos") correctly reflect the underlying list of items.
4.  Optionally, test using the verification script `/home/jules/verification/verify_inventory.py` to ensure visual correctness.

---
*PR created automatically by Jules for task [10477053785225142286](https://jules.google.com/task/10477053785225142286) started by @mateuscarlos*