### PR TITLE
⚡ Bolt: [performance improvement] Optimize inventory stats calculation with reduce and useMemo

### DIFF
--- a/src/modules/inventory/presentation/pages/InventoryPage.tsx
+++ b/src/modules/inventory/presentation/pages/InventoryPage.tsx
@@ -2,7 +2,7 @@
  * Inventory Page
  */
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 import { Plus, Package, AlertTriangle, TrendingDown } from 'lucide-react';
@@ -16,12 +16,21 @@ export function InventoryPage() {
   const [filters, setFilters] = useState<InventoryFilters>({ page: 1, pageSize: 20 });
   const { data, isLoading } = useInventoryItems(filters);
 
-  const stats = {
-    total: data?.data.length || 0,
-    lowStock: data?.data.filter(i => i.status === ItemStatus.LOW_STOCK).length || 0,
-    outOfStock: data?.data.filter(i => i.status === ItemStatus.OUT_OF_STOCK).length || 0,
-    expired: data?.data.filter(i => i.status === ItemStatus.EXPIRED).length || 0,
-  };
+  // ⚡ Bolt: Replaced multiple O(N) filter passes with a single O(N) reduce
+  // pass and memoized the calculation to prevent unnecessary re-renders.
+  const stats = useMemo(() => {
+    const items = data?.data || [];
+    return items.reduce(
+      (acc, item) => {
+        acc.total++;
+        if (item.status === ItemStatus.LOW_STOCK) acc.lowStock++;
+        if (item.status === ItemStatus.OUT_OF_STOCK) acc.outOfStock++;
+        if (item.status === ItemStatus.EXPIRED) acc.expired++;
+        return acc;
+      },
+      { total: 0, lowStock: 0, outOfStock: 0, expired: 0 }
+    );
+  }, [data?.data]);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
💡 What: Replaced three O(N) `.filter().length` passes on the inventory items array with a single O(N) `.reduce()` pass and wrapped the calculation in a `useMemo` hook.

🎯 Why: To prevent the aggregate statistics from recalculating entirely on every component render and to optimize the time complexity of the array traversal. Calculating multiple counts separately is redundant and creates intermediate array allocations.

📊 Impact: Reduces time complexity from O(3N) to O(N) and stops the calculation from running on non-data-related renders (like filter state changes before fetching), reducing React CPU overhead.

🔬 Measurement: Observe the InventoryPage loading with large datasets. The `useMemo` cache ensures stats are only computed exactly when the data payload from `useInventoryItems` changes.

---
*PR created automatically by Jules for task [3350423074456245661](https://jules.google.com/task/3350423074456245661) started by @mateuscarlos*