### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,7 +154,7 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
+              <Button variant="ghost" size="icon" aria-label="Menu mobile">
                 <Menu className="h-6 w-6" />
               </Button>
             </SheetTrigger>

--- a/src/pages/Patients.tsx
+++ b/src/pages/Patients.tsx
@@ -80,7 +80,7 @@ const Patients = () => {
                   className="pl-9 w-[200px] lg:w-[300px]"
                 />
               </div>
-              <Button variant="outline" size="icon">
+              <Button variant="outline" size="icon" aria-label="Filtros">
                 <Filter className="h-4 w-4" />
               </Button>
             </div>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the icon-only mobile Menu button and the Patients Filter button.
🎯 Why: Screen reader users cannot see the icons and therefore don't know the purpose of these buttons. This change ensures that screen readers can correctly announce the actions associated with the buttons.
📸 Before/After: The visual appearance remains exactly the same, but the buttons are now fully accessible to assistive technologies.
♿ Accessibility: The buttons now have explicit `aria-label` texts ("Menu mobile" and "Filtros" respectively) in accordance with WCAG guidelines.

---
*PR created automatically by Jules for task [12036308507589523920](https://jules.google.com/task/12036308507589523920) started by @mateuscarlos*