### PR TITLE
🎨 Palette: Add ARIA label to mobile menu button

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,7 +154,7 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
+              <Button variant="ghost" size="icon" aria-label="Abrir menu de navegação">
                 <Menu className="h-6 w-6" />
               </Button>
             </SheetTrigger>


### PR DESCRIPTION
### 💡 What
Added an `aria-label` attribute (`"Abrir menu de navegação"`) to the mobile hamburger menu button in the main layout (`AppLayout.tsx`).

### 🎯 Why
Icon-only buttons are invisible to screen readers because they lack a textual name. Adding an `aria-label` ensures that visually impaired users relying on assistive technologies know what the button does before interacting with it. Mobile menus often don't have hover states, making `aria-label` the most robust choice.

### 📸 Before/After
No visual changes.

### ♿ Accessibility
- Improves screen reader support by providing a descriptive label for an otherwise empty icon button.

---
*PR created automatically by Jules for task [1258712045258194084](https://jules.google.com/task/1258712045258194084) started by @mateuscarlos*