### PR TITLE
🎨 Palette: Accessibility improvements for icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,7 @@
 ## 2025-01-26 - Icon-Only Button Accessibility
 **Learning:** Icon-only buttons are invisible to screen readers without labels. Tooltips alone are insufficient for AT users.
 **Action:** Pair `Tooltip` (for sighted users) with `aria-label` (for AT users) on every icon button.
+
+## 2024-04-03 - Added aria-label to icon-only buttons
+**Learning:** Verified icon buttons using `<Button size="icon">` in this design system do not inherently enforce accessibility features, necessitating explicit `aria-label` additions. The project mixes routing between `src/pages` and `src/modules/.../presentation/pages`, requiring cross-checks on component modifications. Playwright locators for elements inside `<Sheet>` or `<Dialog>` (Shadcn components) should await visibility explicitly to avoid timeouts, and using `scroll_into_view_if_needed()` ensures hovered/clicked items are interactive when within scrollable areas like `ScrollArea`.
+**Action:** Always ensure any `<Button size="icon">` or custom SVG-only interactive element receives a clear, localized `aria-label`. Use Playwright's `wait_for(state="visible")` aggressively when interacting with Shadcn portals (dialogs/sheets).

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,7 +154,7 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
+              <Button variant="ghost" size="icon" aria-label="Abrir menu de navegação">
                 <Menu className="h-6 w-6" />
               </Button>
             </SheetTrigger>

--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -221,6 +221,7 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                     size="icon"
                     onClick={handleFetchAddress}
                     disabled={loadingCep}
+                    aria-label="Buscar endereço pelo CEP"
                   >
                     {loadingCep ? (
                       <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/pages/Patients.tsx
+++ b/src/pages/Patients.tsx
@@ -80,7 +80,7 @@ const Patients = () => {
                   className="pl-9 w-[200px] lg:w-[300px]"
                 />
               </div>
-              <Button variant="outline" size="icon">
+              <Button variant="outline" size="icon" aria-label="Filtros avançados">
                 <Filter className="h-4 w-4" />
               </Button>
             </div>


### PR DESCRIPTION
### 💡 What
Added `aria-label` attributes to several icon-only buttons across the application:
1. The mobile menu hamburger button (`<Menu>`) in `AppLayout`.
2. The advanced filters toggle button (`<Filter>`) in the Patients page.
3. The "Fetch Address by CEP" button (`<Search>`) in the Patient Form.

### 🎯 Why
Icon-only buttons rely entirely on visual context to convey their purpose. Screen readers and assistive technologies need a textual label to announce the button's action to users who cannot see the icons. These changes ensure the application is more inclusive and complies with standard accessibility guidelines.

### ♿ Accessibility
- Prevents screen readers from announcing "button" without context.
- Provides clear, localized Portuguese text (`Abrir menu de navegação`, `Filtros avançados`, `Buscar endereço pelo CEP`) for key actions.

### 📸 Before/After
*(Visuals remain unchanged. Accessibility tree is now populated with descriptive text nodes for these buttons.)*

---
*PR created automatically by Jules for task [357417942907127498](https://jules.google.com/task/357417942907127498) started by @mateuscarlos*