### PR TITLE
⚡ Bolt: [performance improvement] Optimize inventory stats calculation with O(N) reduce pass

### DIFF
--- a/src/modules/inventory/presentation/pages/InventoryPage.tsx
+++ b/src/modules/inventory/presentation/pages/InventoryPage.tsx
@@ -2,7 +2,7 @@
  * Inventory Page
  */
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 import { Plus, Package, AlertTriangle, TrendingDown } from 'lucide-react';
@@ -16,12 +16,24 @@ export function InventoryPage() {
   const [filters, setFilters] = useState<InventoryFilters>({ page: 1, pageSize: 20 });
   const { data, isLoading } = useInventoryItems(filters);
 
-  const stats = {
-    total: data?.data.length || 0,
-    lowStock: data?.data.filter(i => i.status === ItemStatus.LOW_STOCK).length || 0,
-    outOfStock: data?.data.filter(i => i.status === ItemStatus.OUT_OF_STOCK).length || 0,
-    expired: data?.data.filter(i => i.status === ItemStatus.EXPIRED).length || 0,
-  };
+  // ⚡ Bolt Optimization: Replaced O(3N) multiple filters with O(N) single reduce pass
+  // and memoized the calculation to prevent re-computing on every re-render
+  const stats = useMemo(() => {
+    if (!data?.data) {
+      return { total: 0, lowStock: 0, outOfStock: 0, expired: 0 };
+    }
+
+    return data.data.reduce(
+      (acc, item) => {
+        acc.total += 1;
+        if (item.status === ItemStatus.LOW_STOCK) acc.lowStock += 1;
+        else if (item.status === ItemStatus.OUT_OF_STOCK) acc.outOfStock += 1;
+        else if (item.status === ItemStatus.EXPIRED) acc.expired += 1;
+        return acc;
+      },
+      { total: 0, lowStock: 0, outOfStock: 0, expired: 0 }
+    );
+  }, [data?.data]);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
💡 **What:** Replaced three separate `.filter().length` passes over the `data?.data` array with a single `.reduce()` pass and wrapped the calculation in a `useMemo` hook.

🎯 **Why:** Previously, the `InventoryPage` component iterated over the inventory items array three times to calculate `lowStock`, `outOfStock`, and `expired` counts on every single component render. By using `.reduce()`, the time complexity is reduced from O(3N) to O(N). The `useMemo` hook further optimizes this by ensuring the computation only happens when the underlying data actually changes, avoiding redundant processing on every re-render.

📊 **Impact:** Reduces array iteration overhead by ~66% and eliminates redundant O(N) recalculations during unrelated state updates. On large datasets, this will significantly improve render performance.

🔬 **Measurement:** Verified that the inventory page renders correctly without syntax or type errors. Run `pnpm lint` and `npx tsc --noEmit` to verify.

---
*PR created automatically by Jules for task [15512612281267908751](https://jules.google.com/task/15512612281267908751) started by @mateuscarlos*