### PR TITLE
🎨 Palette: Add tooltip and a11y label to CEP search button

### DIFF
--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -20,6 +20,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Textarea } from '@/shared/ui/textarea';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card';
 import { useToast } from '@/shared/hooks/use-toast';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
 
 interface PatientFormProps {
   onSubmit: (data: PatientFormData) => void;
@@ -215,19 +216,27 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                       setValue('zipCode', unmaskCEP(masked));
                     }}
                   />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    onClick={handleFetchAddress}
-                    disabled={loadingCep}
-                  >
-                    {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Search className="h-4 w-4" />
-                    )}
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={handleFetchAddress}
+                        disabled={loadingCep}
+                        aria-label="Buscar endereço pelo CEP"
+                      >
+                        {loadingCep ? (
+                          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                        ) : (
+                          <Search className="h-4 w-4" aria-hidden="true" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Buscar endereço pelo CEP</p>
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 {errors.zipCode && (
                   <p className="text-sm text-destructive">{errors.zipCode.message}</p>


### PR DESCRIPTION
💡 **What**: Added a `Tooltip` and `aria-label` to the icon-only "Search Address by CEP" button inside the `PatientForm` component. The inner decorative icons (`Loader2` and `Search`) were also marked with `aria-hidden="true"`.

🎯 **Why**: Icon-only buttons without explicit labels are inaccessible to screen readers and can be confusing to sighted users who aren't familiar with what the icon means. This change improves accessibility and discoverability.

📸 **Before/After**: The button now displays a "Buscar endereço pelo CEP" tooltip on hover/focus.

♿ **Accessibility**:
- Sighted users receive an explanatory tooltip on hover.
- Screen reader users hear "Buscar endereço pelo CEP" instead of skipping an unlabeled button.
- Redundant SVG elements are hidden from the accessibility tree.

---
*PR created automatically by Jules for task [3462098038774352970](https://jules.google.com/task/3462098038774352970) started by @mateuscarlos*