### PR TITLE
🎨 Palette: [UX improvement] Add tooltip and ARIA label to CEP search icon button

### DIFF
--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -16,6 +16,7 @@ import { ConfirmationDialog } from '@/shared/ui/confirmation-dialog';
 import { Button } from '@/shared/ui/button';
 import { Input } from '@/shared/ui/input';
 import { Label } from '@/shared/ui/label';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select';
 import { Textarea } from '@/shared/ui/textarea';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card';
@@ -215,19 +216,27 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                       setValue('zipCode', unmaskCEP(masked));
                     }}
                   />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    onClick={handleFetchAddress}
-                    disabled={loadingCep}
-                  >
-                    {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Search className="h-4 w-4" />
-                    )}
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={handleFetchAddress}
+                        disabled={loadingCep}
+                        aria-label="Buscar CEP"
+                      >
+                        {loadingCep ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Search className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Buscar CEP</p>
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 {errors.zipCode && (
                   <p className="text-sm text-destructive">{errors.zipCode.message}</p>


### PR DESCRIPTION
💡 **What:** Added an `aria-label` and visual `Tooltip` to the "Buscar CEP" (Search Address) icon button in the `PatientForm` component. The redundant `TooltipProvider` was removed as it's provided globally.
🎯 **Why:** The button only had an icon (`Search` or `Loader2`) making it ambiguous to sighted users about its functionality and completely invisible/unannounced for screen reader users.
📸 **Before/After:** Before: Just an icon without context or accessible name. After: Fully descriptive tooltip on hover/focus and screen reader announcements.
♿ **Accessibility:** Added an `aria-label="Buscar CEP"` and the standard Shadcn UI Tooltip to comply with icon-button accessibility rules (pairing Tooltip with aria-label).

---
*PR created automatically by Jules for task [15912019213383898685](https://jules.google.com/task/15912019213383898685) started by @mateuscarlos*