### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and tooltips to icon-only buttons

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -154,8 +154,8 @@ const AppLayout = () => {
           
           <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Menu className="h-6 w-6" />
+              <Button variant="ghost" size="icon" aria-label="Abrir menu de navegação">
+                <Menu className="h-6 w-6" aria-hidden="true" />
               </Button>
             </SheetTrigger>
             <SheetContent side="left" className="p-0 w-64">

--- a/src/modules/patients/presentation/components/PatientForm.tsx
+++ b/src/modules/patients/presentation/components/PatientForm.tsx
@@ -20,6 +20,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Textarea } from '@/shared/ui/textarea';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card';
 import { useToast } from '@/shared/hooks/use-toast';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
 
 interface PatientFormProps {
   onSubmit: (data: PatientFormData) => void;
@@ -215,19 +216,27 @@ export function PatientForm({ onSubmit, onCancel }: PatientFormProps) {
                       setValue('zipCode', unmaskCEP(masked));
                     }}
                   />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    onClick={handleFetchAddress}
-                    disabled={loadingCep}
-                  >
-                    {loadingCep ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Search className="h-4 w-4" />
-                    )}
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={handleFetchAddress}
+                        disabled={loadingCep}
+                        aria-label="Buscar endereço pelo CEP"
+                      >
+                        {loadingCep ? (
+                          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                        ) : (
+                          <Search className="h-4 w-4" aria-hidden="true" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Buscar endereço pelo CEP</p>
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 {errors.zipCode && (
                   <p className="text-sm text-destructive">{errors.zipCode.message}</p>


### PR DESCRIPTION
💡 **What**:
Added `aria-label` and `aria-hidden` attributes to icon-only buttons. Added a visual `Tooltip` to the CEP search button.

🎯 **Why**:
Icon-only buttons without accessible names are invisible to screen readers, preventing users relying on assistive technology from understanding what the buttons do. Additionally, sighted users benefit from a tooltip explaining the action of an icon.

📸 **Before/After**:
Before: The "Fetch Address" button in the Patient Form was just a magnifying glass icon. The mobile menu was just a hamburger icon. Both lacked accessible names.
After: Both buttons have clear `aria-label`s. The "Fetch Address" button now displays a helpful "Buscar endereço pelo CEP" tooltip on hover or focus.

♿ **Accessibility**:
*   Added `aria-label="Buscar endereço pelo CEP"` to the patient form search button.
*   Added `aria-label="Abrir menu de navegação"` to the mobile layout menu button.
*   Added `aria-hidden="true"` to the decorative SVG icons (`Search`, `Loader2`, `Menu`) to prevent redundant announcements.
*   Wrapped the search button in standard Shadcn `Tooltip` components to ensure keyboard focus reveals the description for sighted users.

---
*PR created automatically by Jules for task [7713391170697655588](https://jules.google.com/task/7713391170697655588) started by @mateuscarlos*