### PR TITLE
🎨 Palette: [UX improvement] Improve search and filter accessibility in Patients page

### DIFF
--- a/src/pages/Patients.tsx
+++ b/src/pages/Patients.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/shared/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
 import { Plus, Search, Filter } from "lucide-react";
 import { Input } from "@/shared/ui/input";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from "@/shared/ui/sheet";
 import { ScrollArea } from "@/shared/ui/scroll-area";
 import { PatientForm } from "@/modules/patients/presentation/components/PatientForm";
@@ -77,12 +78,19 @@ const Patients = () => {
                 <Input
                   type="search"
                   placeholder="Buscar paciente..."
-                  className="pl-9 w-[200px] lg:w-[300px]"
+                  className="pl-9 w-[200px] lg:w-[300px] [&::-webkit-search-cancel-button]:hidden"
                 />
               </div>
-              <Button variant="outline" size="icon">
-                <Filter className="h-4 w-4" />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" aria-label="Filtros avançados">
+                    <Filter className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Filtros avançados</p>
+                </TooltipContent>
+              </Tooltip>
             </div>
           </div>
         </CardHeader>


### PR DESCRIPTION
**💡 What:** Added a `Tooltip` and `aria-label` to the Filter icon-only button, and hid the browser-native clear button on the Search input.
**🎯 Why:** Icon-only buttons are inaccessible to screen readers without `aria-label`, and confusing to sighted users without a `Tooltip`. Native search inputs show double clear buttons when custom ones are used.
**📸 Before/After:** See attached Playwright video/screenshot showing the tooltip on hover.
**♿ Accessibility:** Improved screen reader support for the Filter button and clearer visual affordance.

---
*PR created automatically by Jules for task [6295544626314020008](https://jules.google.com/task/6295544626314020008) started by @mateuscarlos*